### PR TITLE
refactor: consolidate UPS service code definitions

### DIFF
--- a/src/api/routes/preview.py
+++ b/src/api/routes/preview.py
@@ -29,22 +29,11 @@ from src.services.ups_payload_builder import (
     build_shipper_from_env,
     build_shipper_from_shop,
 )
+from src.services.ups_service_codes import SERVICE_CODE_NAMES
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["preview"])
-
-# UPS service code to name mapping
-SERVICE_CODE_NAMES = {
-    "01": "UPS Next Day Air",
-    "02": "UPS 2nd Day Air",
-    "03": "UPS Ground",
-    "11": "UPS Standard",
-    "12": "UPS 3 Day Select",
-    "13": "UPS Next Day Air Saver",
-    "14": "UPS Next Day Air Early",
-    "59": "UPS 2nd Day Air A.M.",
-}
 
 @router.get("/jobs/{job_id}/preview", response_model=BatchPreviewResponse)
 def get_job_preview(job_id: str, db: Session = Depends(get_db)) -> BatchPreviewResponse:

--- a/src/orchestrator/agent/tools/core.py
+++ b/src/orchestrator/agent/tools/core.py
@@ -16,13 +16,16 @@ from typing import Any
 from uuid import uuid4
 
 from src.db.connection import get_db_context
-from src.orchestrator.models.intent import SERVICE_ALIASES
 from src.services.audit_service import AuditService, EventType
 from src.services.column_mapping import (
     apply_mapping,
     auto_map_columns,
-    translate_service_name,
     validate_mapping,
+)
+from src.services.ups_service_codes import (
+    SERVICE_ALIASES,
+    SERVICE_CODE_NAMES,
+    translate_service_name,
 )
 from src.services.job_service import JobService
 
@@ -340,17 +343,6 @@ async def shutdown_cached_ups_client() -> None:
 # ---------------------------------------------------------------------------
 # Preview Enrichment Helpers
 # ---------------------------------------------------------------------------
-
-SERVICE_CODE_NAMES: dict[str, str] = {
-    "01": "UPS Next Day Air",
-    "02": "UPS 2nd Day Air",
-    "03": "UPS Ground",
-    "11": "UPS Standard",
-    "12": "UPS 3 Day Select",
-    "13": "UPS Next Day Air Saver",
-    "14": "UPS Next Day Air Early",
-    "59": "UPS 2nd Day Air A.M.",
-}
 
 
 def _enrich_preview_rows_from_map(

--- a/src/orchestrator/agent/tools/interactive.py
+++ b/src/orchestrator/agent/tools/interactive.py
@@ -121,8 +121,8 @@ async def preview_interactive_shipment_tool(
         build_shipment_request,
         build_shipper_from_env,
         resolve_packaging_code,
-        resolve_service_code,
     )
+    from src.services.ups_service_codes import resolve_service_code
 
     # Safe coercion: None -> "", non-string -> str, then strip
     def _str(val: Any, default: str = "") -> str:

--- a/src/orchestrator/agent/tools/pipeline.py
+++ b/src/orchestrator/agent/tools/pipeline.py
@@ -10,8 +10,8 @@ import os
 from typing import Any
 
 from src.db.connection import get_db_context
-from src.services.column_mapping import translate_service_name
 from src.services.job_service import JobService
+from src.services.ups_service_codes import translate_service_name
 
 from src.orchestrator.agent.tools.core import (
     EventEmitterBridge,

--- a/src/orchestrator/models/intent.py
+++ b/src/orchestrator/models/intent.py
@@ -4,58 +4,18 @@ These Pydantic models define the structure of parsed user commands,
 including shipping intents, filter criteria, and row qualifiers.
 """
 
-from enum import Enum
 from typing import Literal, Optional
 
 from pydantic import BaseModel, ConfigDict, Field
 
-
-class ServiceCode(str, Enum):
-    """UPS service codes for shipping services.
-
-    These codes correspond to UPS API service type identifiers.
-    """
-
-    GROUND = "03"
-    NEXT_DAY_AIR = "01"
-    SECOND_DAY_AIR = "02"
-    THREE_DAY_SELECT = "12"
-    NEXT_DAY_AIR_SAVER = "13"
-
-
-# Service alias mapping per CONTEXT.md Decision 1
-# Maps user-friendly terms to ServiceCode enum values
-SERVICE_ALIASES: dict[str, ServiceCode] = {
-    # Ground service
-    "ground": ServiceCode.GROUND,
-    "ups ground": ServiceCode.GROUND,
-    # Next Day Air
-    "overnight": ServiceCode.NEXT_DAY_AIR,
-    "next day": ServiceCode.NEXT_DAY_AIR,
-    "next day air": ServiceCode.NEXT_DAY_AIR,
-    "nda": ServiceCode.NEXT_DAY_AIR,
-    # Second Day Air
-    "2-day": ServiceCode.SECOND_DAY_AIR,
-    "2 day": ServiceCode.SECOND_DAY_AIR,
-    "two day": ServiceCode.SECOND_DAY_AIR,
-    "2nd day air": ServiceCode.SECOND_DAY_AIR,
-    "second day air": ServiceCode.SECOND_DAY_AIR,
-    # Three Day Select
-    "3-day": ServiceCode.THREE_DAY_SELECT,
-    "3 day": ServiceCode.THREE_DAY_SELECT,
-    "three day": ServiceCode.THREE_DAY_SELECT,
-    "3 day select": ServiceCode.THREE_DAY_SELECT,
-    "three day select": ServiceCode.THREE_DAY_SELECT,
-    # Next Day Air Saver
-    "saver": ServiceCode.NEXT_DAY_AIR_SAVER,
-    "next day air saver": ServiceCode.NEXT_DAY_AIR_SAVER,
-    "nda saver": ServiceCode.NEXT_DAY_AIR_SAVER,
-}
-
-# Reverse mapping from code value to ServiceCode enum
-CODE_TO_SERVICE: dict[str, ServiceCode] = {
-    code.value: code for code in ServiceCode
-}
+# Re-export canonical service code definitions for backward compatibility.
+# All consumers that import ServiceCode, SERVICE_ALIASES, CODE_TO_SERVICE
+# from this module continue to work unchanged.
+from src.services.ups_service_codes import (  # noqa: F401
+    CODE_TO_SERVICE,
+    SERVICE_ALIASES,
+    ServiceCode,
+)
 
 
 class RowQualifier(BaseModel):

--- a/src/services/column_mapping.py
+++ b/src/services/column_mapping.py
@@ -13,6 +13,8 @@ Example:
 
 from typing import Any
 
+from src.services.ups_service_codes import SERVICE_NAME_TO_CODE, translate_service_name
+
 
 # Fields that must have a mapping entry for valid shipments
 REQUIRED_FIELDS = [
@@ -206,55 +208,5 @@ def auto_map_columns(source_columns: list[str]) -> dict[str, str]:
     return mapping
 
 
-# === Service name translation ===
-
-SERVICE_NAME_TO_CODE: dict[str, str] = {
-    "ground": "03",
-    "ups ground": "03",
-    "2nd day air": "02",
-    "ups 2nd day air": "02",
-    "next day air": "01",
-    "ups next day air": "01",
-    "3 day select": "12",
-    "ups 3 day select": "12",
-    "next day air saver": "13",
-    "ups next day air saver": "13",
-    "next day air early": "14",
-    "ups next day air early": "14",
-    "2nd day air am": "59",
-    "ups 2nd day air am": "59",
-    "standard": "11",
-    "ups standard": "11",
-    "express": "01",
-    "overnight": "01",
-}
-
-
-def translate_service_name(name: str) -> str:
-    """Translate a human-readable service name to a UPS service code.
-
-    Case-insensitive lookup. Returns the original value if already a
-    numeric code or if no match is found.
-
-    Args:
-        name: Service name string (e.g., "Ground", "Next Day Air").
-
-    Returns:
-        UPS service code string (e.g., "03", "01").
-    """
-    if not name:
-        return "03"  # Default to Ground
-
-    stripped = name.strip()
-
-    # Already a code (numeric string)?
-    if stripped.isdigit():
-        return stripped
-
-    # Lookup by lowercase
-    code = SERVICE_NAME_TO_CODE.get(stripped.lower())
-    if code:
-        return code
-
-    # Default to Ground if unrecognized
-    return "03"
+# Re-exported from src.services.ups_service_codes for backward compatibility:
+# SERVICE_NAME_TO_CODE, translate_service_name

--- a/src/services/ups_payload_builder.py
+++ b/src/services/ups_payload_builder.py
@@ -19,6 +19,8 @@ Example:
 import re
 from typing import Any
 
+from src.services.ups_service_codes import resolve_service_code
+
 
 def normalize_phone(phone: str | None) -> str:
     """Normalize phone number to digits only.
@@ -341,74 +343,6 @@ def build_packages(order_data: dict[str, Any]) -> list[dict[str, Any]]:
         package["declaredValue"] = float(declared_value)
 
     return [package]
-
-
-def resolve_service_code(raw_value: str | None, default: str = "03") -> str:
-    """Resolve a service value to a UPS numeric service code.
-
-    Accepts either a numeric code directly (e.g. "03") or a
-    human-readable name (e.g. "Ground", "Next Day Air").
-
-    Args:
-        raw_value: Service code or name string.
-        default: Default service code ("03" = Ground).
-
-    Returns:
-        UPS service code string.
-    """
-    if not raw_value:
-        return default
-
-    stripped = raw_value.strip()
-
-    # Already a valid numeric code
-    if stripped.isdigit():
-        return stripped
-
-    # Map human-readable names to UPS codes (case-insensitive)
-    service_name_map: dict[str, str] = {
-        # Ground
-        "ground": "03",
-        "ups ground": "03",
-        # Next Day Air
-        "next day air": "01",
-        "ups next day air": "01",
-        "next day": "01",
-        "overnight": "01",
-        "express": "01",
-        "nda": "01",
-        # 2nd Day Air
-        "2nd day air": "02",
-        "ups 2nd day air": "02",
-        "2 day": "02",
-        "two day": "02",
-        "second day air": "02",
-        # 3 Day Select
-        "3 day select": "12",
-        "ups 3 day select": "12",
-        "3 day": "12",
-        "three day": "12",
-        # Next Day Air Saver
-        "next day air saver": "13",
-        "ups next day air saver": "13",
-        "nda saver": "13",
-        "saver": "13",
-        # Next Day Air Early
-        "next day air early": "14",
-        "ups next day air early": "14",
-        "next day air early am": "14",
-        "early am": "14",
-        # 2nd Day Air A.M.
-        "2nd day air am": "59",
-        "ups 2nd day air am": "59",
-        "2 day am": "59",
-        "second day air am": "59",
-        # UPS Standard (primarily Canada/Mexico)
-        "standard": "11",
-        "ups standard": "11",
-    }
-
-    return service_name_map.get(stripped.lower(), default)
 
 
 def get_service_code(order_data: dict[str, Any], default: str = "03") -> str:

--- a/src/services/ups_service_codes.py
+++ b/src/services/ups_service_codes.py
@@ -1,0 +1,157 @@
+"""Canonical UPS service code definitions.
+
+Single source of truth for all UPS service code enums, aliases,
+display names, and resolver functions. All other modules import
+from here instead of maintaining their own copies.
+"""
+
+from enum import Enum
+
+
+class ServiceCode(str, Enum):
+    """UPS service codes for shipping services.
+
+    These codes correspond to UPS API service type identifiers.
+    """
+
+    NEXT_DAY_AIR = "01"
+    SECOND_DAY_AIR = "02"
+    GROUND = "03"
+    UPS_STANDARD = "11"
+    THREE_DAY_SELECT = "12"
+    NEXT_DAY_AIR_SAVER = "13"
+    NEXT_DAY_AIR_EARLY = "14"
+    SECOND_DAY_AIR_AM = "59"
+
+
+# ---------------------------------------------------------------------------
+# Alias mapping — maps user-friendly terms to ServiceCode enum values
+# ---------------------------------------------------------------------------
+
+SERVICE_ALIASES: dict[str, ServiceCode] = {
+    # Ground
+    "ground": ServiceCode.GROUND,
+    "ups ground": ServiceCode.GROUND,
+    # Next Day Air
+    "overnight": ServiceCode.NEXT_DAY_AIR,
+    "next day": ServiceCode.NEXT_DAY_AIR,
+    "next day air": ServiceCode.NEXT_DAY_AIR,
+    "ups next day air": ServiceCode.NEXT_DAY_AIR,
+    "nda": ServiceCode.NEXT_DAY_AIR,
+    "express": ServiceCode.NEXT_DAY_AIR,
+    # Second Day Air
+    "2-day": ServiceCode.SECOND_DAY_AIR,
+    "2 day": ServiceCode.SECOND_DAY_AIR,
+    "two day": ServiceCode.SECOND_DAY_AIR,
+    "2nd day air": ServiceCode.SECOND_DAY_AIR,
+    "second day air": ServiceCode.SECOND_DAY_AIR,
+    "ups 2nd day air": ServiceCode.SECOND_DAY_AIR,
+    # Three Day Select
+    "3-day": ServiceCode.THREE_DAY_SELECT,
+    "3 day": ServiceCode.THREE_DAY_SELECT,
+    "three day": ServiceCode.THREE_DAY_SELECT,
+    "3 day select": ServiceCode.THREE_DAY_SELECT,
+    "three day select": ServiceCode.THREE_DAY_SELECT,
+    "ups 3 day select": ServiceCode.THREE_DAY_SELECT,
+    # Next Day Air Saver
+    "saver": ServiceCode.NEXT_DAY_AIR_SAVER,
+    "next day air saver": ServiceCode.NEXT_DAY_AIR_SAVER,
+    "ups next day air saver": ServiceCode.NEXT_DAY_AIR_SAVER,
+    "nda saver": ServiceCode.NEXT_DAY_AIR_SAVER,
+    # Next Day Air Early
+    "next day air early": ServiceCode.NEXT_DAY_AIR_EARLY,
+    "ups next day air early": ServiceCode.NEXT_DAY_AIR_EARLY,
+    "next day air early am": ServiceCode.NEXT_DAY_AIR_EARLY,
+    "early am": ServiceCode.NEXT_DAY_AIR_EARLY,
+    # Second Day Air A.M.
+    "2nd day air am": ServiceCode.SECOND_DAY_AIR_AM,
+    "ups 2nd day air am": ServiceCode.SECOND_DAY_AIR_AM,
+    "2 day am": ServiceCode.SECOND_DAY_AIR_AM,
+    "second day air am": ServiceCode.SECOND_DAY_AIR_AM,
+    # UPS Standard (primarily Canada/Mexico)
+    "ups standard": ServiceCode.UPS_STANDARD,
+    # NOTE: bare "standard" is intentionally aliased — the payload builder's
+    # resolve_service_code already mapped it, and column_mapping did too.
+    "standard": ServiceCode.UPS_STANDARD,
+}
+
+# Reverse mapping: code value → ServiceCode enum member
+CODE_TO_SERVICE: dict[str, ServiceCode] = {code.value: code for code in ServiceCode}
+
+# Display names: code value → human-readable name
+SERVICE_CODE_NAMES: dict[str, str] = {
+    "01": "UPS Next Day Air",
+    "02": "UPS 2nd Day Air",
+    "03": "UPS Ground",
+    "11": "UPS Standard",
+    "12": "UPS 3 Day Select",
+    "13": "UPS Next Day Air Saver",
+    "14": "UPS Next Day Air Early",
+    "59": "UPS 2nd Day Air A.M.",
+}
+
+# Auto-derived string-value alias map (for column_mapping compatibility)
+SERVICE_NAME_TO_CODE: dict[str, str] = {k: v.value for k, v in SERVICE_ALIASES.items()}
+
+# International vs domestic service sets
+SUPPORTED_INTERNATIONAL_SERVICES: frozenset[str] = frozenset({
+    "07",  # UPS Worldwide Express
+    "08",  # UPS Worldwide Expedited
+    "11",  # UPS Standard (CA/MX)
+    "54",  # UPS Worldwide Express Plus
+    "65",  # UPS Worldwide Saver
+})
+
+DOMESTIC_ONLY_SERVICES: frozenset[str] = frozenset({
+    "01",  # Next Day Air
+    "02",  # 2nd Day Air
+    "03",  # Ground
+    "12",  # 3 Day Select
+    "13",  # Next Day Air Saver
+    "14",  # Next Day Air Early
+})
+
+
+def resolve_service_code(raw_value: str | None, default: str = "03") -> str:
+    """Resolve a service value to a UPS numeric service code.
+
+    Accepts either a numeric code directly (e.g. "03") or a
+    human-readable name (e.g. "Ground", "Next Day Air").
+
+    Args:
+        raw_value: Service code or name string.
+        default: Default service code ("03" = Ground).
+
+    Returns:
+        UPS service code string.
+    """
+    if not raw_value:
+        return default
+
+    stripped = raw_value.strip()
+
+    # Already a valid numeric code
+    if stripped.isdigit():
+        return stripped
+
+    # Lookup by lowercase in the alias map
+    matched = SERVICE_ALIASES.get(stripped.lower())
+    if matched is not None:
+        return matched.value
+
+    return default
+
+
+def translate_service_name(name: str) -> str:
+    """Translate a human-readable service name to a UPS service code.
+
+    Case-insensitive lookup. Returns the original value if already a
+    numeric code or if no match is found.
+
+    Args:
+        name: Service name string (e.g., "Ground", "Next Day Air").
+
+    Returns:
+        UPS service code string (e.g., "03", "01").
+    """
+    return resolve_service_code(name)

--- a/tests/orchestrator/test_logistics_filters.py
+++ b/tests/orchestrator/test_logistics_filters.py
@@ -374,8 +374,13 @@ class TestLookupServiceCode:
 
     def test_unknown_passthrough(self):
         """Unknown values pass through unchanged."""
+        result = lookup_service_code("carrier_pigeon")
+        assert result == "carrier_pigeon"
+
+    def test_express_resolves_to_next_day_air(self):
+        """Express is an alias for Next Day Air (01)."""
         result = lookup_service_code("express")
-        assert result == "express"
+        assert result == "01"
 
 
 class TestLogisticsFiltersRegistry:


### PR DESCRIPTION
## Summary
- Creates `src/services/ups_service_codes.py` as the single source of truth for all UPS service code enums, aliases, display names, and resolver functions
- Removes 5 duplicate definitions scattered across `intent.py`, `column_mapping.py`, `ups_payload_builder.py`, `core.py`, and `preview.py`
- Adds missing service codes (`NEXT_DAY_AIR_EARLY=14`, `SECOND_DAY_AIR_AM=59`) to the `ServiceCode` enum
- Merges all alias dicts into a unified 34-entry `SERVICE_ALIASES` with typed `ServiceCode` values
- Consolidates two identical resolver functions (`resolve_service_code` + `translate_service_name`) into one canonical implementation
- Adds `SUPPORTED_INTERNATIONAL_SERVICES` and `DOMESTIC_ONLY_SERVICES` frozensets for upcoming international shipping work
- `intent.py` re-exports ensure zero import breakage for existing consumers

## Test plan
- [x] All 956 tests pass (0 failures)
- [x] Verified no duplicate definitions remain via grep
- [x] Verified all re-export paths work (intent.py, column_mapping.py, ups_payload_builder.py)
- [x] Updated `test_logistics_filters.py` — "express" now correctly resolves to "01" (was previously unrecognized)