### PR TITLE
feat: chat persistence & UI optimization

### DIFF
--- a/docs/plans/2026-02-20-chat-persistence-ui-optimization-design.md
+++ b/docs/plans/2026-02-20-chat-persistence-ui-optimization-design.md
@@ -1,0 +1,447 @@
+# Chat Persistence & UI Optimization Design
+
+**Date:** 2026-02-20
+**Status:** Approved
+**Scope:** Persistent conversation history, visual timeline minimap, copy/export, sidebar integration
+
+---
+
+## 1. Overview
+
+Transition ShipAgent's chat from ephemeral in-memory sessions to database-backed persistent conversations. Users can switch between sessions, resume prior conversations with full agent context, export transcripts, and navigate long threads via a visual timeline.
+
+### Key Decisions (from brainstorming)
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Resume depth | Full resume | Users need to continue complex multi-step workflows |
+| Context restore | Best-effort | Try reconnect; degrade gracefully if source missing |
+| Timeline scope | Same delivery | Ship all features together |
+| History UI location | Existing sidebar | Unify navigation; no new flyout pattern |
+| Title generation | Agent-generated (background Haiku) | Polished titles without polluting main conversation |
+| Export format | JSON only | Structured, machine-readable, simple |
+| Storage depth | Rendered messages only | Tool internals already in decision audit tables |
+| New chat flow | Explicit button + auto-save | Clear signal for context switching |
+| Architecture | DB + system prompt re-injection | Clean, leverages existing patterns, handles restarts |
+| Persistence responsibility | Backend only | Frontend displays; backend persists before `done` event |
+
+---
+
+## 2. Database Schema
+
+New tables in `src/db/models.py`, following existing `Mapped[type]` + `mapped_column` + ISO8601 conventions.
+
+### Enums
+
+```python
+class MessageType(str, Enum):
+    """Type classification for visual timeline rendering."""
+    text = "text"                        # Plain user/assistant text
+    system_artifact = "system_artifact"  # Preview, completion, domain cards
+    error = "error"                      # Error messages
+    tool_call = "tool_call"              # Tool call chips
+```
+
+### ConversationSession
+
+```python
+class ConversationSession(Base):
+    __tablename__ = "conversation_sessions"
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=generate_uuid)
+    title: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    mode: Mapped[str] = mapped_column(String(20), nullable=False, default="batch")
+    context_data: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    is_active: Mapped[bool] = mapped_column(nullable=False, default=True)
+    created_at: Mapped[str] = mapped_column(String(50), nullable=False, default=utc_now_iso)
+    updated_at: Mapped[Optional[str]] = mapped_column(String(50), nullable=True)
+
+    messages = relationship("ConversationMessage", back_populates="session",
+                           cascade="all, delete-orphan", order_by="ConversationMessage.sequence")
+```
+
+### ConversationMessage
+
+```python
+class ConversationMessage(Base):
+    __tablename__ = "conversation_messages"
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=generate_uuid)
+    session_id: Mapped[str] = mapped_column(
+        String(36), ForeignKey("conversation_sessions.id"), nullable=False
+    )
+    role: Mapped[str] = mapped_column(String(20), nullable=False)
+    message_type: Mapped[str] = mapped_column(
+        String(30), nullable=False, default=MessageType.text.value
+    )
+    content: Mapped[str] = mapped_column(Text, nullable=False)
+    metadata_json: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    sequence: Mapped[int] = mapped_column(Integer, nullable=False)
+    created_at: Mapped[str] = mapped_column(String(50), nullable=False, default=utc_now_iso)
+
+    session = relationship("ConversationSession", back_populates="messages")
+```
+
+### Indexes
+
+- `(session_id, sequence)` — Ordered message retrieval
+- `(session_id, message_type)` — Timeline queries
+- `(is_active, updated_at)` — Sidebar session listing
+
+### context_data JSON Structure
+
+```json
+{
+  "data_source_id": "saved-source-uuid-or-null",
+  "source_name": "Q3_Orders.csv",
+  "source_type": "csv",
+  "agent_source_hash": "abc123...",
+  "filter_state": null
+}
+```
+
+The `agent_source_hash` enables staleness detection on resume — if the hash changed, the data source was modified since the session was active.
+
+---
+
+## 3. Backend Services
+
+### ConversationPersistenceService (`src/services/conversation_persistence_service.py`)
+
+New service with these operations:
+
+| Method | Purpose |
+|--------|---------|
+| `create_session(mode, context_data?)` | Insert new `ConversationSession` row |
+| `save_message(session_id, role, content, message_type, metadata?)` | Append message with auto-incrementing sequence |
+| `list_sessions(active_only=True)` | Lightweight list: id, title, mode, timestamps, message_count |
+| `get_session_with_messages(session_id, limit?, offset?)` | Full hydration with pagination |
+| `update_session_title(session_id, title)` | Set agent-generated title |
+| `update_session_context(session_id, context_data)` | Snapshot context (on data source change) |
+| `soft_delete_session(session_id)` | Set `is_active = False` |
+| `export_session_json(session_id)` | Full session + messages as JSON dict |
+
+### Title Generation Service
+
+After the first assistant response is saved to DB, a background `asyncio.Task` fires:
+
+1. Takes first user prompt + first assistant response text
+2. Calls Claude Haiku with a minimal prompt: `"Generate a concise 3-6 word title for this shipping conversation: [user]: {prompt} [assistant]: {response}"`
+3. Saves result via `update_session_title()`
+4. Frontend polls or receives title update via next SSE keepalive cycle
+
+This is a fire-and-forget background task — title appears asynchronously in the sidebar.
+
+### Message Persistence Points (Backend-Owned)
+
+**User messages:** Persisted in the `send_message` route handler (`POST /conversations/{id}/messages`) before dispatching to the agent. The frontend does NOT write messages.
+
+**Assistant messages:** Persisted in `_process_agent_message()` after the agent finishes generating (after the response loop completes, before emitting the `done` SSE event). The accumulated text + detected message_type + metadata are saved as a single `ConversationMessage` row.
+
+**Artifact messages:** When tool events emit artifacts (preview_ready, completion, pickup_preview, etc.), the artifact metadata is captured and saved as a separate `ConversationMessage` with `message_type = "system_artifact"` and the artifact payload in `metadata_json`.
+
+**Error messages:** Exceptions in `_process_agent_message()` are saved with `message_type = "error"` before the error SSE event is emitted.
+
+### Agent Resume Architecture
+
+When a user loads a prior session and sends a new message:
+
+1. `AgentSessionManager.get_or_create_session(session_id)` detects no in-memory session
+2. Loads `ConversationSession` + messages from DB
+3. Reads `mode` from session → creates agent with correct `interactive_shipping` flag
+4. `build_system_prompt()` receives a new `prior_conversation` parameter — a formatted string of the message history:
+   ```
+   ## Prior Conversation (Resumed Session)
+   You are resuming a prior conversation. Here is the history:
+
+   [user]: Ship all orders from Q3_Orders.csv via UPS Ground
+   [assistant]: I'll help with that. Let me check the data source...
+   [user]: Only ship orders to California
+   [assistant]: I'll filter for California addresses...
+   ```
+5. Best-effort context restore: parse `context_data` → check data source exists → reconnect or emit warning banner via SSE
+6. Agent processes the new message with full conversational context
+
+---
+
+## 4. API Endpoints
+
+### New Endpoints
+
+| Method | Path | Request | Response |
+|--------|------|---------|----------|
+| `GET /conversations` | List active sessions | `?active_only=true` | `[{id, title, mode, created_at, updated_at, message_count}]` |
+| `GET /conversations/{id}/messages` | Load history | `?limit=50&offset=0` | `{session: {...}, messages: [{id, role, message_type, content, metadata, sequence, created_at}]}` |
+| `PATCH /conversations/{id}` | Update title | `{title: "..."}` | `{id, title}` |
+| `DELETE /conversations/{id}` | Soft delete | — | `204 No Content` |
+| `GET /conversations/{id}/export` | Export JSON | — | `application/json` download |
+
+### Modified Endpoints
+
+| Method | Path | Change |
+|--------|------|--------|
+| `POST /conversations/` | Create session | Also creates `ConversationSession` DB row |
+| `POST /conversations/{id}/messages` | Send message | Persists user message to DB before dispatching |
+| `DELETE /conversations/{id}` | Delete session | Soft-deletes DB row (was: in-memory only) |
+
+---
+
+## 5. Frontend Architecture
+
+### State Changes (`useAppState.tsx`)
+
+```typescript
+// New state
+chatSessions: ChatSessionSummary[];
+setChatSessions: (sessions: ChatSessionSummary[]) => void;
+chatSessionsVersion: number;        // Refresh trigger (like jobListVersion)
+refreshChatSessions: () => void;    // Increment version counter
+activeSessionTitle: string | null;
+setActiveSessionTitle: (title: string | null) => void;
+
+interface ChatSessionSummary {
+  id: string;
+  title: string | null;
+  mode: "batch" | "interactive";
+  created_at: string;
+  updated_at: string | null;
+  message_count: number;
+}
+```
+
+### Hook Changes (`useConversation.ts`)
+
+| Function | Change |
+|----------|--------|
+| `sendMessage()` | No change to persistence (backend handles it). Still creates session lazily. |
+| `loadSession(sessionId)` | NEW. Fetches messages from `GET /conversations/{id}/messages`. Sets mode FIRST (prevents flicker), then populates `AppState.conversation`, connects SSE. |
+| `reset()` | Modified: auto-saves implicitly (session already in DB). Disconnects SSE, clears events, increments epoch. Does NOT delete the session. |
+| `startNewChat()` | NEW. Calls `reset()`, clears `AppState.conversation`, resets `conversationSessionId` to null. Shows WelcomeMessage. |
+
+**Critical:** `loadSession()` must set `interactiveShipping` from the session's `mode` field BEFORE rendering messages to prevent UI mode flickering.
+
+### API Client (`lib/api.ts`)
+
+New functions:
+
+```typescript
+export async function listConversations(): Promise<ChatSessionSummary[]>
+export async function getConversationMessages(id: string, limit?: number, offset?: number): Promise<SessionDetail>
+export async function updateConversationTitle(id: string, title: string): Promise<void>
+export async function deleteConversation(id: string): Promise<void>  // existing, now soft-delete
+export async function exportConversation(id: string): Promise<Blob>
+```
+
+### TypeScript Types (`types/api.ts`)
+
+```typescript
+interface ChatSessionSummary {
+  id: string;
+  title: string | null;
+  mode: "batch" | "interactive";
+  created_at: string;
+  updated_at: string | null;
+  message_count: number;
+}
+
+interface SessionDetail {
+  session: ChatSessionSummary;
+  messages: PersistedMessage[];
+}
+
+interface PersistedMessage {
+  id: string;
+  role: "user" | "assistant" | "system";
+  message_type: "text" | "system_artifact" | "error" | "tool_call";
+  content: string;
+  metadata: Record<string, unknown> | null;
+  sequence: number;
+  created_at: string;
+}
+```
+
+---
+
+## 6. Visual Components
+
+### ChatSessionsPanel (`frontend/src/components/sidebar/ChatSessionsPanel.tsx`)
+
+**Location:** Middle section of existing sidebar (between Data Source and Job History).
+
+**Layout:**
+- Header: "Chat Sessions" label + "New Chat" button (`btn-primary`, small)
+- Collapsible with max-height and internal scrolling
+- Session list grouped by: Today, Yesterday, Previous 7 Days, Older
+
+**Session item:**
+- Title text (or "New conversation..." muted if untitled)
+- Mode badge: `badge-shipping` (batch) or small "Interactive" pill
+- Relative timestamp ("2m ago", "Yesterday")
+- Trash icon on hover (right side)
+- Active session: left border accent in primary color
+
+**Empty state:** "No conversations yet. Start typing to begin."
+
+### ChatTimeline (`frontend/src/components/command-center/ChatTimeline.tsx`)
+
+**Layout:** 16px gutter on right edge of chat scroll container. Thin 2px vertical line with color-coded dots.
+
+**Dot colors (OKLCH):**
+- Grey `oklch(0.7 0 0)`: User text (`message_type = "text"`, `role = "user"`)
+- Cyan `oklch(0.75 0.15 195)`: Assistant text (`message_type = "text"`, `role = "assistant"`)
+- Amber `oklch(0.8 0.15 85)`: Artifacts (`message_type = "system_artifact"`)
+- Red `oklch(0.7 0.18 25)`: Errors (`message_type = "error"`)
+
+**Behavior:**
+- Dots positioned proportionally: `top = (message.sequence / totalMessages) * 100%`
+- Single `IntersectionObserver` with `threshold: 0.5` tracks visible messages
+- Visible message range highlighted with subtle glow/size increase on corresponding dots
+- Click dot → `document.querySelector([data-message-id=...]).scrollIntoView({ behavior: 'smooth' })`
+- Each rendered message element gets `data-message-id={message.id}` attribute
+
+### CopyButton Enhancement (`messages.tsx`)
+
+**Component:** `CopyButton` — appears on hover at top-right of message bubbles.
+
+```tsx
+function CopyButton({ text }: { text: string }) {
+  const [copied, setCopied] = useState(false);
+  const handleCopy = async () => {
+    await navigator.clipboard.writeText(text);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1500);
+  };
+  return (
+    <button onClick={handleCopy} className="opacity-0 group-hover:opacity-100 transition-opacity">
+      {copied ? <CheckIcon /> : <CopyIcon />}
+    </button>
+  );
+}
+```
+
+**Scope:** User messages and assistant text messages only. Artifact cards (PreviewCard, CompletionArtifact, etc.) do not get copy buttons.
+
+### Export Button
+
+**Location:** Inside the ChatSessionsPanel, per-session action (alongside trash). Small download icon.
+
+**Behavior:** Calls `GET /conversations/{id}/export` → triggers browser file download as `{title}-{date}.json`.
+
+---
+
+## 7. Data Flow Diagrams
+
+### New Message Flow (with persistence)
+
+```
+User types → CommandCenter.sendMessage()
+  → useConversation.ensureSession() [lazy create]
+  → POST /conversations/{id}/messages
+     ├─ Backend persists user message to DB (role=user, type=text)
+     ├─ Dispatches _process_agent_message() background task
+     │   ├─ Agent processes message
+     │   ├─ Accumulates response text + artifact events
+     │   ├─ On completion:
+     │   │   ├─ Persist assistant message to DB (role=assistant, type=text)
+     │   │   ├─ Persist artifact messages to DB (role=system, type=system_artifact)
+     │   │   └─ Emit "done" SSE event
+     │   └─ On error:
+     │       ├─ Persist error message to DB (role=system, type=error)
+     │       └─ Emit "error" SSE event
+     └─ Returns 202 ACCEPTED
+  → SSE events stream to frontend for real-time display
+```
+
+### Session Resume Flow
+
+```
+User clicks session in sidebar
+  → useConversation.loadSession(sessionId)
+     ├─ GET /conversations/{id}/messages
+     ├─ Read session.mode → setInteractiveShipping() [BEFORE rendering]
+     ├─ Populate AppState.conversation from messages
+     ├─ Parse context_data → best-effort data source reconnect
+     │   ├─ Source exists + hash matches → reconnect silently
+     │   ├─ Source exists + hash changed → reconnect + warn "Source modified"
+     │   └─ Source missing → warn "Original data source unavailable"
+     ├─ Connect SSE for new events
+     └─ Set conversationSessionId
+  → User can now send new messages (agent gets history via system prompt)
+```
+
+### New Chat Flow
+
+```
+User clicks "New Chat" button
+  → startNewChat()
+     ├─ Disconnect current SSE
+     ├─ Clear AppState.conversation
+     ├─ Set conversationSessionId = null
+     ├─ Refresh sidebar (chatSessionsVersion++)
+     └─ Show WelcomeMessage
+  → User types first message
+     → Lazy session creation (existing pattern)
+     → New ConversationSession row created in DB
+```
+
+---
+
+## 8. File Impact Summary
+
+### New Files
+
+| File | Purpose |
+|------|---------|
+| `src/services/conversation_persistence_service.py` | DB persistence service for sessions + messages |
+| `frontend/src/components/sidebar/ChatSessionsPanel.tsx` | Chat sessions sidebar panel |
+| `frontend/src/components/command-center/ChatTimeline.tsx` | Visual timeline minimap |
+
+### Modified Files
+
+| File | Changes |
+|------|---------|
+| `src/db/models.py` | Add `MessageType` enum, `ConversationSession`, `ConversationMessage` models |
+| `src/db/connection.py` | Ensure new tables created on startup |
+| `src/api/routes/conversations.py` | Add list/delete/export endpoints; modify create/send to persist |
+| `src/api/schemas_conversations.py` | Add response schemas for session list, messages, export |
+| `src/services/agent_session_manager.py` | Add `resume_session()` path; integrate with persistence service |
+| `src/orchestrator/agent/system_prompt.py` | Add `prior_conversation` section to `build_system_prompt()` |
+| `frontend/src/lib/api.ts` | Add `listConversations`, `getConversationMessages`, `exportConversation`, `updateConversationTitle` |
+| `frontend/src/types/api.ts` | Add `ChatSessionSummary`, `SessionDetail`, `PersistedMessage` types |
+| `frontend/src/hooks/useAppState.tsx` | Add `chatSessions`, `chatSessionsVersion`, `activeSessionTitle` state |
+| `frontend/src/hooks/useConversation.ts` | Add `loadSession()`, `startNewChat()`; modify `reset()` to not delete |
+| `frontend/src/components/CommandCenter.tsx` | Integrate timeline gutter; add `data-message-id` to messages |
+| `frontend/src/components/command-center/messages.tsx` | Add `CopyButton` on hover for message bubbles |
+| `frontend/src/components/layout/Sidebar.tsx` | Add `ChatSessionsPanel` section between data source and job history |
+
+### Test Files (New)
+
+| File | Coverage |
+|------|----------|
+| `tests/services/test_conversation_persistence_service.py` | CRUD, pagination, soft delete, export |
+| `tests/api/test_conversations_persistence.py` | API endpoint integration tests |
+| `tests/orchestrator/agent/test_system_prompt_resume.py` | Prior conversation injection |
+
+---
+
+## 9. Risks & Mitigations
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Context mismatch (deleted data source) | Medium | Best-effort restore with degraded-mode warning banner |
+| System prompt token bloat on long conversations | Medium | Truncate prior conversation to last ~30 messages; summarize earlier messages |
+| Performance on 1000+ message sessions | Low | Pagination (`limit`/`offset`) on message fetch; timeline maps to loaded messages |
+| Sidebar vertical space with 3 panels | Low | Chat sessions panel collapsible with max-height internal scroll |
+| Title generation race condition | Low | Fire-and-forget background task; frontend polls on sidebar refresh |
+| SDK agent context loss on resume | Medium | System prompt injection gives context; agent cannot recall exact tool results but has conversational summary |
+
+---
+
+## 10. Non-Goals (Explicit Exclusions)
+
+- Real-time collaboration (multiple users in same session)
+- Full event replay (tool_call/tool_result storage — handled by decision audit)
+- PDF/Markdown export (JSON only for V1)
+- Session sharing or linking
+- Auto-save drafts (user input not persisted until sent)
+- Search across all sessions (V1: search within sidebar list by title only)

--- a/docs/plans/2026-02-20-chat-persistence-ui-optimization-implementation.md
+++ b/docs/plans/2026-02-20-chat-persistence-ui-optimization-implementation.md
@@ -1,0 +1,2452 @@
+# Chat Persistence & UI Optimization Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Transition ShipAgent chat from ephemeral in-memory sessions to database-backed persistent conversations with full resume, visual timeline minimap, copy-to-clipboard, and sidebar chat session management.
+
+**Architecture:** DB-persisted messages + system prompt re-injection for agent resume. Backend owns all persistence (messages saved in route handlers, not frontend). Frontend is display-only for history. Visual timeline uses IntersectionObserver on message elements.
+
+**Tech Stack:** SQLAlchemy 2.0 (Mapped types), FastAPI, React, TypeScript, OKLCH design system, shadcn/ui patterns.
+
+---
+
+## Task 1: Database Models — ConversationSession & ConversationMessage
+
+**Files:**
+- Modify: `src/db/models.py:691` (append after CustomCommand)
+
+**Step 1: Write failing tests for the new models**
+
+Create `tests/db/test_conversation_models.py`:
+
+```python
+"""Tests for ConversationSession and ConversationMessage models."""
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+
+from src.db.models import (
+    Base,
+    ConversationMessage,
+    ConversationSession,
+    MessageType,
+    generate_uuid,
+    utc_now_iso,
+)
+
+
+@pytest.fixture
+def db_session():
+    """Create an in-memory SQLite session for testing."""
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    SessionLocal = sessionmaker(bind=engine)
+    session = SessionLocal()
+    yield session
+    session.close()
+
+
+class TestMessageTypeEnum:
+    """MessageType enum values and str inheritance."""
+
+    def test_text_value(self):
+        assert MessageType.text.value == "text"
+
+    def test_system_artifact_value(self):
+        assert MessageType.system_artifact.value == "system_artifact"
+
+    def test_error_value(self):
+        assert MessageType.error.value == "error"
+
+    def test_tool_call_value(self):
+        assert MessageType.tool_call.value == "tool_call"
+
+    def test_is_string(self):
+        assert isinstance(MessageType.text, str)
+
+
+class TestConversationSession:
+    """ConversationSession model CRUD."""
+
+    def test_create_session_defaults(self, db_session: Session):
+        session = ConversationSession(id=generate_uuid())
+        db_session.add(session)
+        db_session.commit()
+
+        assert session.mode == "batch"
+        assert session.is_active is True
+        assert session.title is None
+        assert session.context_data is None
+        assert session.created_at is not None
+
+    def test_create_session_interactive(self, db_session: Session):
+        session = ConversationSession(
+            id=generate_uuid(),
+            mode="interactive",
+            title="Test Session",
+        )
+        db_session.add(session)
+        db_session.commit()
+
+        assert session.mode == "interactive"
+        assert session.title == "Test Session"
+
+    def test_soft_delete(self, db_session: Session):
+        session = ConversationSession(id=generate_uuid())
+        db_session.add(session)
+        db_session.commit()
+
+        session.is_active = False
+        db_session.commit()
+
+        result = db_session.query(ConversationSession).filter_by(
+            is_active=True
+        ).all()
+        assert len(result) == 0
+
+    def test_context_data_json(self, db_session: Session):
+        import json
+        ctx = json.dumps({"data_source_id": "abc", "agent_source_hash": "xyz"})
+        session = ConversationSession(id=generate_uuid(), context_data=ctx)
+        db_session.add(session)
+        db_session.commit()
+
+        loaded = json.loads(session.context_data)
+        assert loaded["data_source_id"] == "abc"
+        assert loaded["agent_source_hash"] == "xyz"
+
+
+class TestConversationMessage:
+    """ConversationMessage model CRUD and relationships."""
+
+    def _make_session(self, db_session: Session) -> ConversationSession:
+        s = ConversationSession(id=generate_uuid())
+        db_session.add(s)
+        db_session.commit()
+        return s
+
+    def test_create_message(self, db_session: Session):
+        s = self._make_session(db_session)
+        msg = ConversationMessage(
+            id=generate_uuid(),
+            session_id=s.id,
+            role="user",
+            content="Ship all CA orders",
+            sequence=1,
+        )
+        db_session.add(msg)
+        db_session.commit()
+
+        assert msg.message_type == MessageType.text.value
+        assert msg.role == "user"
+        assert msg.sequence == 1
+
+    def test_message_types(self, db_session: Session):
+        s = self._make_session(db_session)
+        for i, mt in enumerate(MessageType):
+            msg = ConversationMessage(
+                id=generate_uuid(),
+                session_id=s.id,
+                role="system",
+                message_type=mt.value,
+                content=f"test {mt.value}",
+                sequence=i,
+            )
+            db_session.add(msg)
+        db_session.commit()
+
+        msgs = db_session.query(ConversationMessage).filter_by(
+            session_id=s.id
+        ).order_by(ConversationMessage.sequence).all()
+        assert len(msgs) == len(MessageType)
+
+    def test_relationship_cascade_delete(self, db_session: Session):
+        s = self._make_session(db_session)
+        for i in range(3):
+            db_session.add(ConversationMessage(
+                id=generate_uuid(),
+                session_id=s.id,
+                role="user",
+                content=f"msg {i}",
+                sequence=i,
+            ))
+        db_session.commit()
+
+        db_session.delete(s)
+        db_session.commit()
+
+        remaining = db_session.query(ConversationMessage).all()
+        assert len(remaining) == 0
+
+    def test_ordering_by_sequence(self, db_session: Session):
+        s = self._make_session(db_session)
+        for seq in [3, 1, 2]:
+            db_session.add(ConversationMessage(
+                id=generate_uuid(),
+                session_id=s.id,
+                role="user",
+                content=f"seq {seq}",
+                sequence=seq,
+            ))
+        db_session.commit()
+
+        msgs = db_session.query(ConversationMessage).filter_by(
+            session_id=s.id
+        ).order_by(ConversationMessage.sequence).all()
+        assert [m.sequence for m in msgs] == [1, 2, 3]
+
+    def test_metadata_json_nullable(self, db_session: Session):
+        s = self._make_session(db_session)
+        msg = ConversationMessage(
+            id=generate_uuid(),
+            session_id=s.id,
+            role="assistant",
+            content="Done",
+            sequence=1,
+            metadata_json=None,
+        )
+        db_session.add(msg)
+        db_session.commit()
+        assert msg.metadata_json is None
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/db/test_conversation_models.py -v`
+Expected: FAIL with `ImportError: cannot import name 'ConversationSession' from 'src.db.models'`
+
+**Step 3: Implement the models**
+
+Add to `src/db/models.py` after line 691 (after `CustomCommand`):
+
+```python
+class MessageType(str, Enum):
+    """Type classification for conversation messages.
+
+    Used by the visual timeline to determine dot color without
+    parsing metadata JSON.
+    """
+
+    text = "text"
+    system_artifact = "system_artifact"
+    error = "error"
+    tool_call = "tool_call"
+
+
+class ConversationSession(Base):
+    """Persistent conversation session.
+
+    Stores session metadata including mode, title, and context data
+    (active data source, source hash) for context-aware resume.
+
+    Attributes:
+        id: UUID primary key (same as runtime session_id).
+        title: Agent-generated title (nullable until first response).
+        mode: Shipping mode — 'batch' or 'interactive'.
+        context_data: JSON blob with data source reference and agent_source_hash.
+        is_active: Soft delete flag (False = archived).
+        created_at: ISO8601 creation timestamp.
+        updated_at: ISO8601 last-update timestamp.
+    """
+
+    __tablename__ = "conversation_sessions"
+    __table_args__ = (
+        Index("ix_convsess_active_updated", "is_active", "updated_at"),
+    )
+
+    id: Mapped[str] = mapped_column(
+        String(36), primary_key=True, default=generate_uuid
+    )
+    title: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    mode: Mapped[str] = mapped_column(
+        String(20), nullable=False, default="batch"
+    )
+    context_data: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    is_active: Mapped[bool] = mapped_column(nullable=False, default=True)
+    created_at: Mapped[str] = mapped_column(
+        String(50), nullable=False, default=utc_now_iso
+    )
+    updated_at: Mapped[Optional[str]] = mapped_column(String(50), nullable=True)
+
+    messages: Mapped[list["ConversationMessage"]] = relationship(
+        "ConversationMessage",
+        back_populates="session",
+        cascade="all, delete-orphan",
+        order_by="ConversationMessage.sequence",
+    )
+
+    def __repr__(self) -> str:
+        return f"<ConversationSession(id={self.id!r}, title={self.title!r})>"
+
+
+class ConversationMessage(Base):
+    """Persistent conversation message.
+
+    Stores rendered messages (user text, agent text, artifacts, errors)
+    for history display and agent context re-injection on resume.
+
+    Attributes:
+        id: UUID primary key.
+        session_id: FK to ConversationSession.
+        role: Message role — 'user', 'assistant', or 'system'.
+        message_type: Classification for timeline rendering.
+        content: Message text content.
+        metadata_json: Optional JSON with artifact data (action, preview, etc.).
+        sequence: Ordering within session (monotonically increasing).
+        created_at: ISO8601 creation timestamp.
+    """
+
+    __tablename__ = "conversation_messages"
+    __table_args__ = (
+        Index("ix_convmsg_session_seq", "session_id", "sequence"),
+        Index("ix_convmsg_session_type", "session_id", "message_type"),
+    )
+
+    id: Mapped[str] = mapped_column(
+        String(36), primary_key=True, default=generate_uuid
+    )
+    session_id: Mapped[str] = mapped_column(
+        String(36), ForeignKey("conversation_sessions.id"), nullable=False
+    )
+    role: Mapped[str] = mapped_column(String(20), nullable=False)
+    message_type: Mapped[str] = mapped_column(
+        String(30), nullable=False, default=MessageType.text.value
+    )
+    content: Mapped[str] = mapped_column(Text, nullable=False)
+    metadata_json: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    sequence: Mapped[int] = mapped_column(Integer, nullable=False)
+    created_at: Mapped[str] = mapped_column(
+        String(50), nullable=False, default=utc_now_iso
+    )
+
+    session: Mapped["ConversationSession"] = relationship(
+        "ConversationSession", back_populates="messages"
+    )
+
+    def __repr__(self) -> str:
+        return (
+            f"<ConversationMessage(id={self.id!r}, role={self.role!r}, "
+            f"seq={self.sequence})>"
+        )
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/db/test_conversation_models.py -v`
+Expected: All PASS
+
+**Step 5: Commit**
+
+```bash
+git add src/db/models.py tests/db/test_conversation_models.py
+git commit -m "feat: add ConversationSession and ConversationMessage DB models"
+```
+
+---
+
+## Task 2: Conversation Persistence Service
+
+**Files:**
+- Create: `src/services/conversation_persistence_service.py`
+- Test: `tests/services/test_conversation_persistence_service.py`
+
+**Step 1: Write failing tests**
+
+Create `tests/services/test_conversation_persistence_service.py`:
+
+```python
+"""Tests for ConversationPersistenceService."""
+
+import json
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+
+from src.db.models import Base, ConversationSession, MessageType
+from src.services.conversation_persistence_service import (
+    ConversationPersistenceService,
+)
+
+
+@pytest.fixture
+def db_session():
+    """In-memory SQLite for testing."""
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    SessionLocal = sessionmaker(bind=engine)
+    session = SessionLocal()
+    yield session
+    session.close()
+
+
+@pytest.fixture
+def svc(db_session: Session):
+    """Service under test."""
+    return ConversationPersistenceService(db_session)
+
+
+class TestCreateSession:
+    def test_creates_batch_session(self, svc, db_session):
+        sess = svc.create_session(session_id="test-1", mode="batch")
+        assert sess.id == "test-1"
+        assert sess.mode == "batch"
+        assert sess.is_active is True
+
+    def test_creates_interactive_session(self, svc, db_session):
+        sess = svc.create_session(session_id="test-2", mode="interactive")
+        assert sess.mode == "interactive"
+
+    def test_stores_context_data(self, svc, db_session):
+        ctx = {"data_source_id": "abc", "agent_source_hash": "xyz"}
+        sess = svc.create_session(
+            session_id="test-3", mode="batch", context_data=ctx,
+        )
+        loaded = json.loads(sess.context_data)
+        assert loaded["data_source_id"] == "abc"
+
+
+class TestSaveMessage:
+    def test_saves_user_message(self, svc, db_session):
+        svc.create_session(session_id="s1", mode="batch")
+        msg = svc.save_message("s1", role="user", content="Hello")
+        assert msg.role == "user"
+        assert msg.sequence == 1
+        assert msg.message_type == MessageType.text.value
+
+    def test_auto_increments_sequence(self, svc, db_session):
+        svc.create_session(session_id="s1", mode="batch")
+        m1 = svc.save_message("s1", role="user", content="First")
+        m2 = svc.save_message("s1", role="assistant", content="Second")
+        assert m1.sequence == 1
+        assert m2.sequence == 2
+
+    def test_saves_artifact_message(self, svc, db_session):
+        svc.create_session(session_id="s1", mode="batch")
+        metadata = {"action": "preview", "jobId": "j1"}
+        msg = svc.save_message(
+            "s1", role="system", content="Preview ready",
+            message_type=MessageType.system_artifact.value,
+            metadata=metadata,
+        )
+        assert msg.message_type == MessageType.system_artifact.value
+        loaded = json.loads(msg.metadata_json)
+        assert loaded["jobId"] == "j1"
+
+    def test_updates_session_updated_at(self, svc, db_session):
+        svc.create_session(session_id="s1", mode="batch")
+        svc.save_message("s1", role="user", content="test")
+        sess = db_session.query(ConversationSession).get("s1")
+        assert sess.updated_at is not None
+
+
+class TestListSessions:
+    def test_lists_active_sessions(self, svc, db_session):
+        svc.create_session(session_id="s1", mode="batch")
+        svc.create_session(session_id="s2", mode="interactive")
+        svc.save_message("s1", role="user", content="msg")
+        results = svc.list_sessions()
+        assert len(results) == 2
+
+    def test_excludes_inactive(self, svc, db_session):
+        svc.create_session(session_id="s1", mode="batch")
+        svc.soft_delete_session("s1")
+        results = svc.list_sessions(active_only=True)
+        assert len(results) == 0
+
+    def test_includes_message_count(self, svc, db_session):
+        svc.create_session(session_id="s1", mode="batch")
+        svc.save_message("s1", role="user", content="a")
+        svc.save_message("s1", role="assistant", content="b")
+        results = svc.list_sessions()
+        assert results[0]["message_count"] == 2
+
+
+class TestGetSessionWithMessages:
+    def test_returns_ordered_messages(self, svc, db_session):
+        svc.create_session(session_id="s1", mode="batch")
+        svc.save_message("s1", role="user", content="first")
+        svc.save_message("s1", role="assistant", content="second")
+        result = svc.get_session_with_messages("s1")
+        assert result is not None
+        assert len(result["messages"]) == 2
+        assert result["messages"][0]["content"] == "first"
+        assert result["messages"][1]["content"] == "second"
+
+    def test_pagination(self, svc, db_session):
+        svc.create_session(session_id="s1", mode="batch")
+        for i in range(10):
+            svc.save_message("s1", role="user", content=f"msg {i}")
+        result = svc.get_session_with_messages("s1", limit=3, offset=2)
+        assert len(result["messages"]) == 3
+        assert result["messages"][0]["content"] == "msg 2"
+
+    def test_returns_none_for_missing(self, svc, db_session):
+        result = svc.get_session_with_messages("nonexistent")
+        assert result is None
+
+
+class TestUpdateTitle:
+    def test_updates_title(self, svc, db_session):
+        svc.create_session(session_id="s1", mode="batch")
+        svc.update_session_title("s1", "Ground Batch - Q3")
+        sess = db_session.query(ConversationSession).get("s1")
+        assert sess.title == "Ground Batch - Q3"
+
+
+class TestUpdateContext:
+    def test_updates_context(self, svc, db_session):
+        svc.create_session(session_id="s1", mode="batch")
+        svc.update_session_context("s1", {"source": "new.csv"})
+        sess = db_session.query(ConversationSession).get("s1")
+        loaded = json.loads(sess.context_data)
+        assert loaded["source"] == "new.csv"
+
+
+class TestSoftDelete:
+    def test_soft_deletes(self, svc, db_session):
+        svc.create_session(session_id="s1", mode="batch")
+        svc.soft_delete_session("s1")
+        sess = db_session.query(ConversationSession).get("s1")
+        assert sess.is_active is False
+
+
+class TestExport:
+    def test_exports_full_session(self, svc, db_session):
+        svc.create_session(session_id="s1", mode="batch")
+        svc.save_message("s1", role="user", content="hello")
+        svc.save_message("s1", role="assistant", content="hi")
+        export = svc.export_session_json("s1")
+        assert export["session"]["id"] == "s1"
+        assert len(export["messages"]) == 2
+
+    def test_export_missing_returns_none(self, svc, db_session):
+        assert svc.export_session_json("nope") is None
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/services/test_conversation_persistence_service.py -v`
+Expected: FAIL with `ModuleNotFoundError`
+
+**Step 3: Implement the service**
+
+Create `src/services/conversation_persistence_service.py`:
+
+```python
+"""Persistence service for conversation sessions and messages.
+
+Thin layer between API routes and SQLAlchemy models. All conversation
+history reads and writes go through this service. The frontend never
+writes messages — the backend owns all persistence.
+"""
+
+import json
+from typing import Any, Optional
+
+from sqlalchemy.orm import Session
+
+from src.db.models import (
+    ConversationMessage,
+    ConversationSession,
+    MessageType,
+    generate_uuid,
+    utc_now_iso,
+)
+
+
+class ConversationPersistenceService:
+    """CRUD operations for persistent conversation sessions and messages.
+
+    Args:
+        db: SQLAlchemy session (sync).
+    """
+
+    def __init__(self, db: Session) -> None:
+        self._db = db
+
+    def create_session(
+        self,
+        session_id: str,
+        mode: str = "batch",
+        context_data: dict[str, Any] | None = None,
+    ) -> ConversationSession:
+        """Create a new conversation session row.
+
+        Args:
+            session_id: UUID for the session (matches runtime session_id).
+            mode: 'batch' or 'interactive'.
+            context_data: Optional JSON-serializable context snapshot.
+
+        Returns:
+            The created ConversationSession.
+        """
+        session = ConversationSession(
+            id=session_id,
+            mode=mode,
+            context_data=json.dumps(context_data) if context_data else None,
+        )
+        self._db.add(session)
+        self._db.commit()
+        return session
+
+    def save_message(
+        self,
+        session_id: str,
+        role: str,
+        content: str,
+        message_type: str = MessageType.text.value,
+        metadata: dict[str, Any] | None = None,
+    ) -> ConversationMessage:
+        """Append a message to a session with auto-incrementing sequence.
+
+        Args:
+            session_id: Parent session ID.
+            role: 'user', 'assistant', or 'system'.
+            content: Message text.
+            message_type: Classification for timeline (default 'text').
+            metadata: Optional artifact metadata dict.
+
+        Returns:
+            The created ConversationMessage.
+        """
+        # Compute next sequence number
+        max_seq = (
+            self._db.query(ConversationMessage.sequence)
+            .filter_by(session_id=session_id)
+            .order_by(ConversationMessage.sequence.desc())
+            .first()
+        )
+        next_seq = (max_seq[0] + 1) if max_seq else 1
+
+        msg = ConversationMessage(
+            id=generate_uuid(),
+            session_id=session_id,
+            role=role,
+            message_type=message_type,
+            content=content,
+            metadata_json=json.dumps(metadata) if metadata else None,
+            sequence=next_seq,
+        )
+        self._db.add(msg)
+
+        # Update session's updated_at
+        session = self._db.query(ConversationSession).get(session_id)
+        if session:
+            session.updated_at = utc_now_iso()
+
+        self._db.commit()
+        return msg
+
+    def list_sessions(
+        self, active_only: bool = True
+    ) -> list[dict[str, Any]]:
+        """List conversation sessions with message counts.
+
+        Args:
+            active_only: If True, exclude soft-deleted sessions.
+
+        Returns:
+            List of session summary dicts.
+        """
+        from sqlalchemy import func
+
+        query = self._db.query(
+            ConversationSession,
+            func.count(ConversationMessage.id).label("message_count"),
+        ).outerjoin(ConversationMessage).group_by(ConversationSession.id)
+
+        if active_only:
+            query = query.filter(ConversationSession.is_active == True)  # noqa: E712
+
+        query = query.order_by(ConversationSession.created_at.desc())
+
+        results = []
+        for session, count in query.all():
+            results.append({
+                "id": session.id,
+                "title": session.title,
+                "mode": session.mode,
+                "created_at": session.created_at,
+                "updated_at": session.updated_at,
+                "message_count": count,
+            })
+        return results
+
+    def get_session_with_messages(
+        self,
+        session_id: str,
+        limit: int | None = None,
+        offset: int = 0,
+    ) -> dict[str, Any] | None:
+        """Load a session with its messages for resume/display.
+
+        Args:
+            session_id: Session ID.
+            limit: Max messages to return (None = all).
+            offset: Skip first N messages.
+
+        Returns:
+            Dict with 'session' and 'messages' keys, or None if not found.
+        """
+        session = self._db.query(ConversationSession).get(session_id)
+        if session is None:
+            return None
+
+        query = (
+            self._db.query(ConversationMessage)
+            .filter_by(session_id=session_id)
+            .order_by(ConversationMessage.sequence)
+            .offset(offset)
+        )
+        if limit is not None:
+            query = query.limit(limit)
+
+        messages = [
+            {
+                "id": m.id,
+                "role": m.role,
+                "message_type": m.message_type,
+                "content": m.content,
+                "metadata": json.loads(m.metadata_json) if m.metadata_json else None,
+                "sequence": m.sequence,
+                "created_at": m.created_at,
+            }
+            for m in query.all()
+        ]
+
+        return {
+            "session": {
+                "id": session.id,
+                "title": session.title,
+                "mode": session.mode,
+                "context_data": json.loads(session.context_data) if session.context_data else None,
+                "is_active": session.is_active,
+                "created_at": session.created_at,
+                "updated_at": session.updated_at,
+            },
+            "messages": messages,
+        }
+
+    def update_session_title(self, session_id: str, title: str) -> None:
+        """Set the session title.
+
+        Args:
+            session_id: Session ID.
+            title: New title string.
+        """
+        session = self._db.query(ConversationSession).get(session_id)
+        if session:
+            session.title = title
+            session.updated_at = utc_now_iso()
+            self._db.commit()
+
+    def update_session_context(
+        self, session_id: str, context_data: dict[str, Any]
+    ) -> None:
+        """Update the session's context snapshot.
+
+        Args:
+            session_id: Session ID.
+            context_data: New context dict.
+        """
+        session = self._db.query(ConversationSession).get(session_id)
+        if session:
+            session.context_data = json.dumps(context_data)
+            session.updated_at = utc_now_iso()
+            self._db.commit()
+
+    def soft_delete_session(self, session_id: str) -> None:
+        """Soft-delete a session (set is_active = False).
+
+        Args:
+            session_id: Session ID.
+        """
+        session = self._db.query(ConversationSession).get(session_id)
+        if session:
+            session.is_active = False
+            session.updated_at = utc_now_iso()
+            self._db.commit()
+
+    def export_session_json(
+        self, session_id: str
+    ) -> dict[str, Any] | None:
+        """Export a full session with all messages as JSON.
+
+        Args:
+            session_id: Session ID.
+
+        Returns:
+            Complete session dict suitable for JSON download, or None.
+        """
+        result = self.get_session_with_messages(session_id)
+        if result is None:
+            return None
+
+        return {
+            "exported_at": utc_now_iso(),
+            "session": result["session"],
+            "messages": result["messages"],
+        }
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/services/test_conversation_persistence_service.py -v`
+Expected: All PASS
+
+**Step 5: Commit**
+
+```bash
+git add src/services/conversation_persistence_service.py tests/services/test_conversation_persistence_service.py
+git commit -m "feat: add ConversationPersistenceService for chat history CRUD"
+```
+
+---
+
+## Task 3: API Schemas for Chat Sessions
+
+**Files:**
+- Modify: `src/api/schemas_conversations.py` (append new schemas)
+
+**Step 1: Write failing test**
+
+Create `tests/api/test_conversation_schemas.py`:
+
+```python
+"""Tests for conversation persistence Pydantic schemas."""
+
+from src.api.schemas_conversations import (
+    ChatSessionSummary,
+    SessionDetailResponse,
+    PersistedMessageResponse,
+    UpdateTitleRequest,
+)
+
+
+def test_chat_session_summary_fields():
+    s = ChatSessionSummary(
+        id="abc",
+        title="Test",
+        mode="batch",
+        created_at="2026-02-20T00:00:00Z",
+        updated_at=None,
+        message_count=5,
+    )
+    assert s.id == "abc"
+    assert s.message_count == 5
+
+
+def test_persisted_message_response():
+    m = PersistedMessageResponse(
+        id="msg-1",
+        role="user",
+        message_type="text",
+        content="hello",
+        metadata=None,
+        sequence=1,
+        created_at="2026-02-20T00:00:00Z",
+    )
+    assert m.sequence == 1
+
+
+def test_session_detail_response():
+    r = SessionDetailResponse(
+        session=ChatSessionSummary(
+            id="s1", title=None, mode="interactive",
+            created_at="2026-02-20T00:00:00Z",
+            updated_at=None, message_count=0,
+        ),
+        messages=[],
+    )
+    assert r.session.mode == "interactive"
+
+
+def test_update_title_request():
+    req = UpdateTitleRequest(title="New Title")
+    assert req.title == "New Title"
+```
+
+**Step 2: Run to verify fail**
+
+Run: `pytest tests/api/test_conversation_schemas.py -v`
+Expected: FAIL with `ImportError`
+
+**Step 3: Add schemas to `src/api/schemas_conversations.py`**
+
+Append after existing schemas (after line 81):
+
+```python
+class ChatSessionSummary(BaseModel):
+    """Lightweight session summary for sidebar listing."""
+
+    id: str
+    title: str | None
+    mode: str
+    created_at: str
+    updated_at: str | None
+    message_count: int
+
+
+class PersistedMessageResponse(BaseModel):
+    """Persisted message for history display."""
+
+    id: str
+    role: str
+    message_type: str
+    content: str
+    metadata: dict | None
+    sequence: int
+    created_at: str
+
+
+class SessionDetailResponse(BaseModel):
+    """Full session with messages for resume."""
+
+    session: ChatSessionSummary
+    messages: list[PersistedMessageResponse]
+
+
+class UpdateTitleRequest(BaseModel):
+    """Request to rename a session."""
+
+    title: str
+```
+
+**Step 4: Run tests**
+
+Run: `pytest tests/api/test_conversation_schemas.py -v`
+Expected: All PASS
+
+**Step 5: Commit**
+
+```bash
+git add src/api/schemas_conversations.py tests/api/test_conversation_schemas.py
+git commit -m "feat: add Pydantic schemas for chat session persistence"
+```
+
+---
+
+## Task 4: API Endpoints — List, Messages, Delete, Export, Update Title
+
+**Files:**
+- Modify: `src/api/routes/conversations.py` (add new endpoints, modify existing create/send/delete)
+
+**Step 1: Write failing integration tests**
+
+Create `tests/api/test_conversations_persistence.py`:
+
+```python
+"""Integration tests for conversation persistence API endpoints."""
+
+import json
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from src.db.models import Base
+
+
+@pytest.fixture
+def db_session():
+    """In-memory SQLite for testing."""
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    SessionLocal = sessionmaker(bind=engine)
+    session = SessionLocal()
+    yield session
+    session.close()
+
+
+@pytest.fixture
+def persistence_svc(db_session):
+    """ConversationPersistenceService for seeding test data."""
+    from src.services.conversation_persistence_service import (
+        ConversationPersistenceService,
+    )
+    return ConversationPersistenceService(db_session)
+
+
+class TestListConversations:
+    """GET /conversations endpoint."""
+
+    def test_list_returns_sessions(self, persistence_svc, db_session):
+        persistence_svc.create_session(session_id="s1", mode="batch")
+        persistence_svc.create_session(session_id="s2", mode="interactive")
+        sessions = persistence_svc.list_sessions()
+        assert len(sessions) == 2
+
+    def test_list_excludes_deleted(self, persistence_svc, db_session):
+        persistence_svc.create_session(session_id="s1", mode="batch")
+        persistence_svc.soft_delete_session("s1")
+        sessions = persistence_svc.list_sessions(active_only=True)
+        assert len(sessions) == 0
+
+
+class TestGetMessages:
+    """GET /conversations/{id}/messages endpoint."""
+
+    def test_returns_ordered_messages(self, persistence_svc, db_session):
+        persistence_svc.create_session(session_id="s1", mode="batch")
+        persistence_svc.save_message("s1", "user", "first")
+        persistence_svc.save_message("s1", "assistant", "second")
+        result = persistence_svc.get_session_with_messages("s1")
+        assert len(result["messages"]) == 2
+        assert result["messages"][0]["role"] == "user"
+
+    def test_pagination(self, persistence_svc, db_session):
+        persistence_svc.create_session(session_id="s1", mode="batch")
+        for i in range(10):
+            persistence_svc.save_message("s1", "user", f"msg {i}")
+        result = persistence_svc.get_session_with_messages("s1", limit=5)
+        assert len(result["messages"]) == 5
+
+
+class TestSoftDelete:
+    """DELETE /conversations/{id} soft delete."""
+
+    def test_soft_deletes(self, persistence_svc, db_session):
+        persistence_svc.create_session(session_id="s1", mode="batch")
+        persistence_svc.soft_delete_session("s1")
+        from src.db.models import ConversationSession
+        sess = db_session.query(ConversationSession).get("s1")
+        assert sess.is_active is False
+
+
+class TestExport:
+    """GET /conversations/{id}/export."""
+
+    def test_exports_json(self, persistence_svc, db_session):
+        persistence_svc.create_session(session_id="s1", mode="batch")
+        persistence_svc.save_message("s1", "user", "hello")
+        export = persistence_svc.export_session_json("s1")
+        assert export["session"]["id"] == "s1"
+        assert len(export["messages"]) == 1
+        assert "exported_at" in export
+
+    def test_export_missing_returns_none(self, persistence_svc):
+        assert persistence_svc.export_session_json("nope") is None
+
+
+class TestUpdateTitle:
+    """PATCH /conversations/{id}."""
+
+    def test_updates_title(self, persistence_svc, db_session):
+        persistence_svc.create_session(session_id="s1", mode="batch")
+        persistence_svc.update_session_title("s1", "Ground Batch")
+        from src.db.models import ConversationSession
+        sess = db_session.query(ConversationSession).get("s1")
+        assert sess.title == "Ground Batch"
+```
+
+**Step 2: Run tests**
+
+Run: `pytest tests/api/test_conversations_persistence.py -v`
+Expected: All PASS (these test the service layer directly; route integration requires the running app)
+
+**Step 3: Add API endpoints to `src/api/routes/conversations.py`**
+
+Add these new endpoints. The exact insertion points:
+
+1. After imports (top of file), add:
+```python
+from src.services.conversation_persistence_service import ConversationPersistenceService
+from src.api.schemas_conversations import (
+    ChatSessionSummary,
+    SessionDetailResponse,
+    PersistedMessageResponse,
+    UpdateTitleRequest,
+)
+```
+
+2. Add a module-level helper to get the persistence service (after `_event_queues` on line 69):
+```python
+def _get_persistence_service() -> ConversationPersistenceService:
+    """Get a ConversationPersistenceService with a fresh DB session."""
+    from src.db.connection import SessionLocal
+    return ConversationPersistenceService(SessionLocal())
+```
+
+3. Add new endpoints before the `shutdown_conversation_runtime` function (before line 939):
+
+```python
+@router.get("/", response_model=list[ChatSessionSummary])
+async def list_conversations(
+    active_only: bool = True,
+) -> list[ChatSessionSummary]:
+    """List conversation sessions for the sidebar.
+
+    Args:
+        active_only: If True, exclude soft-deleted sessions.
+
+    Returns:
+        List of session summaries ordered by recency.
+    """
+    svc = _get_persistence_service()
+    sessions = svc.list_sessions(active_only=active_only)
+    return [ChatSessionSummary(**s) for s in sessions]
+
+
+@router.get("/{session_id}/messages", response_model=SessionDetailResponse)
+async def get_session_messages(
+    session_id: str,
+    limit: int | None = None,
+    offset: int = 0,
+) -> SessionDetailResponse:
+    """Load a session's message history for resume/display.
+
+    Args:
+        session_id: Conversation session ID.
+        limit: Max messages to return.
+        offset: Skip first N messages.
+
+    Returns:
+        Session metadata and ordered messages.
+
+    Raises:
+        HTTPException: 404 if session not found.
+    """
+    svc = _get_persistence_service()
+    result = svc.get_session_with_messages(session_id, limit=limit, offset=offset)
+    if result is None:
+        raise HTTPException(status_code=404, detail="Session not found")
+
+    return SessionDetailResponse(
+        session=ChatSessionSummary(**result["session"], message_count=len(result["messages"])),
+        messages=[PersistedMessageResponse(**m) for m in result["messages"]],
+    )
+
+
+@router.patch("/{session_id}")
+async def update_conversation(
+    session_id: str,
+    payload: UpdateTitleRequest,
+) -> dict:
+    """Update a conversation session's title.
+
+    Args:
+        session_id: Conversation session ID.
+        payload: Title update request.
+
+    Returns:
+        Updated session ID and title.
+    """
+    svc = _get_persistence_service()
+    svc.update_session_title(session_id, payload.title)
+    return {"id": session_id, "title": payload.title}
+
+
+@router.get("/{session_id}/export")
+async def export_conversation(session_id: str) -> Response:
+    """Export a conversation session as JSON download.
+
+    Args:
+        session_id: Conversation session ID.
+
+    Returns:
+        JSON file download.
+
+    Raises:
+        HTTPException: 404 if session not found.
+    """
+    import json as json_mod
+
+    svc = _get_persistence_service()
+    export = svc.export_session_json(session_id)
+    if export is None:
+        raise HTTPException(status_code=404, detail="Session not found")
+
+    title_slug = (export["session"].get("title") or "conversation").replace(" ", "-").lower()[:30]
+    filename = f"{title_slug}-{session_id[:8]}.json"
+
+    return Response(
+        content=json_mod.dumps(export, indent=2),
+        media_type="application/json",
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+    )
+```
+
+4. **Modify `create_conversation`** (line 637): After creating the in-memory session, also create a DB row:
+
+Add after line 656 (`session.interactive_shipping = effective_payload.interactive_shipping`):
+```python
+    # Persist session to database
+    try:
+        persistence = _get_persistence_service()
+        persistence.create_session(
+            session_id=session_id,
+            mode="interactive" if effective_payload.interactive_shipping else "batch",
+        )
+    except Exception as e:
+        logger.warning("Failed to persist session %s to DB: %s", session_id, e)
+```
+
+5. **Modify `send_message`** (line 685): After storing in-memory, also persist user message to DB:
+
+Add after line 713 (`_session_manager.add_message(session_id, "user", payload.content)`):
+```python
+    # Persist user message to database
+    try:
+        persistence = _get_persistence_service()
+        persistence.save_message(session_id, "user", payload.content)
+    except Exception as e:
+        logger.warning("Failed to persist user message to DB: %s", e)
+```
+
+6. **Modify `_process_agent_message`**: After the agent finishes, persist assistant message to DB.
+
+Add after line 483 (the block that adds agent message to in-memory history when `buffered_agent_messages` has content and no artifact was emitted):
+```python
+                        # Persist assistant message to DB
+                        try:
+                            persistence = _get_persistence_service()
+                            persistence.save_message(
+                                session_id, "assistant", final_text,
+                            )
+                        except Exception as exc:
+                            logger.warning("Failed to persist assistant msg: %s", exc)
+```
+
+Also add persistence for non-transient agent messages (after line 442):
+```python
+                            # Persist assistant message to DB
+                            try:
+                                persistence = _get_persistence_service()
+                                persistence.save_message(
+                                    session_id, "assistant", text,
+                                )
+                            except Exception as exc:
+                                logger.warning("Failed to persist assistant msg: %s", exc)
+```
+
+And persist artifact events — add after line 461 (`await queue.put(event)`), inside the artifact_events check:
+```python
+                    # Persist artifact events to DB
+                    if isinstance(event_type, str) and event_type in artifact_events:
+                        try:
+                            persistence = _get_persistence_service()
+                            persistence.save_message(
+                                session_id,
+                                "system",
+                                event_type,
+                                message_type="system_artifact",
+                                metadata=event.get("data"),
+                            )
+                        except Exception as exc:
+                            logger.warning("Failed to persist artifact event: %s", exc)
+```
+
+7. **Modify `delete_conversation`** (line 910): Change to soft-delete instead of hard-delete:
+
+Add before line 933 (`_session_manager.remove_session(session_id)`):
+```python
+    # Soft-delete from database (keep for history)
+    try:
+        persistence = _get_persistence_service()
+        persistence.soft_delete_session(session_id)
+    except Exception as e:
+        logger.warning("Failed to soft-delete session %s from DB: %s", session_id, e)
+```
+
+**Step 4: Run tests**
+
+Run: `pytest tests/api/test_conversations_persistence.py tests/services/test_conversation_persistence_service.py -v`
+Expected: All PASS
+
+**Step 5: Commit**
+
+```bash
+git add src/api/routes/conversations.py src/api/schemas_conversations.py tests/api/test_conversations_persistence.py
+git commit -m "feat: add conversation persistence API endpoints (list, messages, export, title)"
+```
+
+---
+
+## Task 5: System Prompt — Prior Conversation Injection
+
+**Files:**
+- Modify: `src/orchestrator/agent/system_prompt.py:257` (add `prior_conversation` parameter)
+- Test: `tests/orchestrator/agent/test_system_prompt_resume.py`
+
+**Step 1: Write failing test**
+
+Create `tests/orchestrator/agent/test_system_prompt_resume.py`:
+
+```python
+"""Tests for prior conversation injection in system prompt."""
+
+from src.orchestrator.agent.system_prompt import build_system_prompt
+
+
+def test_no_prior_conversation_by_default():
+    prompt = build_system_prompt()
+    assert "Prior Conversation" not in prompt
+
+
+def test_prior_conversation_injected():
+    history = [
+        {"role": "user", "content": "Ship CA orders via Ground"},
+        {"role": "assistant", "content": "I'll help with that."},
+    ]
+    prompt = build_system_prompt(prior_conversation=history)
+    assert "Prior Conversation" in prompt
+    assert "Ship CA orders via Ground" in prompt
+    assert "I'll help with that." in prompt
+
+
+def test_prior_conversation_truncation():
+    history = [
+        {"role": "user", "content": f"Message {i}"}
+        for i in range(50)
+    ]
+    prompt = build_system_prompt(prior_conversation=history)
+    # Should truncate to last ~30 messages
+    assert "Message 49" in prompt
+    assert "Message 0" not in prompt
+
+
+def test_prior_conversation_empty_list():
+    prompt = build_system_prompt(prior_conversation=[])
+    assert "Prior Conversation" not in prompt
+```
+
+**Step 2: Run to verify fail**
+
+Run: `pytest tests/orchestrator/agent/test_system_prompt_resume.py -v`
+Expected: FAIL with `TypeError: build_system_prompt() got an unexpected keyword argument 'prior_conversation'`
+
+**Step 3: Modify `build_system_prompt()` in `src/orchestrator/agent/system_prompt.py`**
+
+Update the function signature at line 257 to add the new parameter:
+
+```python
+def build_system_prompt(
+    source_info: DataSourceInfo | None = None,
+    interactive_shipping: bool = False,
+    column_samples: dict[str, list] | None = None,
+    contacts: list[dict] | None = None,
+    prior_conversation: list[dict] | None = None,
+) -> str:
+```
+
+Add a new helper function before `build_system_prompt` (around line 255):
+
+```python
+MAX_RESUME_MESSAGES = 30
+
+
+def _build_prior_conversation_section(
+    messages: list[dict],
+) -> str:
+    """Build a prior conversation section for session resume.
+
+    Truncates to the last MAX_RESUME_MESSAGES to control prompt size.
+
+    Args:
+        messages: List of {role, content} dicts from persisted history.
+
+    Returns:
+        Formatted conversation history section, or empty string.
+    """
+    if not messages:
+        return ""
+
+    truncated = messages[-MAX_RESUME_MESSAGES:]
+    lines = [
+        "## Prior Conversation (Resumed Session)",
+        "",
+        "You are resuming a prior conversation. Here is the recent history:",
+        "",
+    ]
+    for msg in truncated:
+        role = msg.get("role", "unknown")
+        content = msg.get("content", "")
+        # Truncate very long messages in history
+        if len(content) > 500:
+            content = content[:497] + "..."
+        lines.append(f"[{role}]: {content}")
+
+    if len(messages) > MAX_RESUME_MESSAGES:
+        omitted = len(messages) - MAX_RESUME_MESSAGES
+        lines.insert(4, f"({omitted} earlier messages omitted)")
+        lines.insert(5, "")
+
+    return "\n".join(lines)
+```
+
+At the end of `build_system_prompt()`, before the final return (line 580+), add:
+
+```python
+    # Prior conversation section for session resume
+    prior_section = ""
+    if prior_conversation:
+        prior_section = _build_prior_conversation_section(prior_conversation)
+```
+
+And include `{prior_section}` in the f-string return, after `{contacts_section}` (around line 592):
+
+```python
+{contacts_section}
+{prior_section}
+## Filter Generation Rules
+```
+
+**Step 4: Run tests**
+
+Run: `pytest tests/orchestrator/agent/test_system_prompt_resume.py -v`
+Expected: All PASS
+
+**Step 5: Commit**
+
+```bash
+git add src/orchestrator/agent/system_prompt.py tests/orchestrator/agent/test_system_prompt_resume.py
+git commit -m "feat: add prior conversation injection to system prompt for session resume"
+```
+
+---
+
+## Task 6: Frontend — TypeScript Types & API Client
+
+**Files:**
+- Modify: `frontend/src/types/api.ts` (add new types)
+- Modify: `frontend/src/lib/api.ts` (add new API functions)
+
+**Step 1: Add TypeScript types to `frontend/src/types/api.ts`**
+
+Append after existing types:
+
+```typescript
+// === Chat Session Persistence ===
+
+export interface ChatSessionSummary {
+  id: string;
+  title: string | null;
+  mode: 'batch' | 'interactive';
+  created_at: string;
+  updated_at: string | null;
+  message_count: number;
+}
+
+export interface PersistedMessage {
+  id: string;
+  role: 'user' | 'assistant' | 'system';
+  message_type: 'text' | 'system_artifact' | 'error' | 'tool_call';
+  content: string;
+  metadata: Record<string, unknown> | null;
+  sequence: number;
+  created_at: string;
+}
+
+export interface SessionDetail {
+  session: ChatSessionSummary;
+  messages: PersistedMessage[];
+}
+```
+
+**Step 2: Add API functions to `frontend/src/lib/api.ts`**
+
+Add after `deleteConversation` (after line 458):
+
+```typescript
+// === Chat Session Persistence API ===
+
+import type { ChatSessionSummary, SessionDetail } from '@/types/api';
+
+/**
+ * List conversation sessions for the sidebar.
+ */
+export async function listConversations(
+  activeOnly = true,
+): Promise<ChatSessionSummary[]> {
+  const response = await fetch(
+    `${API_BASE}/conversations/?active_only=${activeOnly}`,
+  );
+  return parseResponse<ChatSessionSummary[]>(response);
+}
+
+/**
+ * Load a session's message history for resume/display.
+ */
+export async function getConversationMessages(
+  sessionId: string,
+  limit?: number,
+  offset = 0,
+): Promise<SessionDetail> {
+  const params = new URLSearchParams({ offset: String(offset) });
+  if (limit !== undefined) params.set('limit', String(limit));
+  const response = await fetch(
+    `${API_BASE}/conversations/${sessionId}/messages?${params}`,
+  );
+  return parseResponse<SessionDetail>(response);
+}
+
+/**
+ * Update a conversation session's title.
+ */
+export async function updateConversationTitle(
+  sessionId: string,
+  title: string,
+): Promise<void> {
+  const response = await fetch(`${API_BASE}/conversations/${sessionId}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ title }),
+  });
+  if (!response.ok) await parseResponse(response);
+}
+
+/**
+ * Export a conversation session as JSON file download.
+ */
+export async function exportConversation(sessionId: string): Promise<void> {
+  const response = await fetch(
+    `${API_BASE}/conversations/${sessionId}/export`,
+  );
+  if (!response.ok) throw new ApiError(response.status, 'Export failed');
+  const blob = await response.blob();
+  const disposition = response.headers.get('Content-Disposition') || '';
+  const match = disposition.match(/filename="(.+?)"/);
+  const filename = match?.[1] || 'conversation-export.json';
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  a.click();
+  URL.revokeObjectURL(url);
+}
+```
+
+**Step 3: Verify TypeScript compiles**
+
+Run: `cd frontend && npx tsc --noEmit`
+Expected: No errors
+
+**Step 4: Commit**
+
+```bash
+git add frontend/src/types/api.ts frontend/src/lib/api.ts
+git commit -m "feat: add chat session persistence types and API client functions"
+```
+
+---
+
+## Task 7: Frontend — AppState & useConversation Changes
+
+**Files:**
+- Modify: `frontend/src/hooks/useAppState.tsx` (add chat session state)
+- Modify: `frontend/src/hooks/useConversation.ts` (add loadSession, startNewChat, modify reset)
+
+**Step 1: Add state to `useAppState.tsx`**
+
+In the `AppState` interface (after line 173, before the closing `}`):
+
+```typescript
+  // Chat session history for sidebar
+  chatSessions: ChatSessionSummary[];
+  setChatSessions: (sessions: ChatSessionSummary[]) => void;
+  chatSessionsVersion: number;
+  refreshChatSessions: () => void;
+  activeSessionTitle: string | null;
+  setActiveSessionTitle: (title: string | null) => void;
+```
+
+Add the import at top:
+```typescript
+import type { ChatSessionSummary } from '@/types/api';
+```
+
+In the `AppStateProvider` (add state declarations after existing ones around line 184+):
+
+```typescript
+  const [chatSessions, setChatSessions] = React.useState<ChatSessionSummary[]>([]);
+  const [chatSessionsVersion, setChatSessionsVersion] = React.useState(0);
+  const [activeSessionTitle, setActiveSessionTitle] = React.useState<string | null>(null);
+
+  const refreshChatSessions = React.useCallback(() => {
+    setChatSessionsVersion((v) => v + 1);
+  }, []);
+```
+
+Add these to the context value object:
+```typescript
+  chatSessions,
+  setChatSessions,
+  chatSessionsVersion,
+  refreshChatSessions,
+  activeSessionTitle,
+  setActiveSessionTitle,
+```
+
+**Step 2: Add `loadSession` and `startNewChat` to `useConversation.ts`**
+
+Add new functions to the hook. After the `reset` function:
+
+```typescript
+  const loadSession = useCallback(async (
+    sessionId: string,
+    mode: 'batch' | 'interactive',
+    messages: ConversationMessage[],
+  ) => {
+    // Close current SSE and clear events (without deleting old session)
+    if (eventSourceRef.current) {
+      eventSourceRef.current.close();
+      eventSourceRef.current = null;
+    }
+    sessionGenerationRef.current += 1;
+    setEvents([]);
+
+    // Set the new session
+    sessionIdRef.current = sessionId;
+    sessionModeRef.current = mode === 'interactive';
+    setSessionId(sessionId);
+
+    // Connect SSE for live events on this session
+    connectSSE(sessionId);
+  }, [connectSSE]);
+
+  const startNewChat = useCallback(async () => {
+    // Close current SSE without deleting session (it auto-saved)
+    if (eventSourceRef.current) {
+      eventSourceRef.current.close();
+      eventSourceRef.current = null;
+    }
+    sessionGenerationRef.current += 1;
+    setEvents([]);
+    sessionIdRef.current = null;
+    sessionModeRef.current = null;
+    creatingSessionPromiseRef.current = null;
+    setSessionId(null);
+    setIsProcessing(false);
+  }, []);
+```
+
+Add to the return interface:
+```typescript
+  loadSession,
+  startNewChat,
+```
+
+Update the `UseConversationReturn` interface to include:
+```typescript
+  loadSession: (sessionId: string, mode: 'batch' | 'interactive', messages: ConversationMessage[]) => Promise<void>;
+  startNewChat: () => Promise<void>;
+```
+
+**Step 3: Modify `reset()` to NOT delete the session**
+
+In the existing `reset` function, change the session deletion to be conditional — only delete if no persistence (for mode switches where user wants to start fresh):
+
+The key change: when `reset()` is called from mode switching, it should still delete. When called from `startNewChat()`, it should not. The simplest approach: `startNewChat()` handles its own cleanup without calling `reset()`.
+
+No change needed to `reset()` — it already works correctly for mode switches. `startNewChat()` is a separate function that preserves the session.
+
+**Step 4: Verify TypeScript compiles**
+
+Run: `cd frontend && npx tsc --noEmit`
+Expected: No errors
+
+**Step 5: Commit**
+
+```bash
+git add frontend/src/hooks/useAppState.tsx frontend/src/hooks/useConversation.ts
+git commit -m "feat: add chat session state and loadSession/startNewChat to hooks"
+```
+
+---
+
+## Task 8: Frontend — ChatSessionsPanel Component
+
+**Files:**
+- Create: `frontend/src/components/sidebar/ChatSessionsPanel.tsx`
+- Modify: `frontend/src/components/layout/Sidebar.tsx` (integrate panel)
+
+**Step 1: Create `ChatSessionsPanel.tsx`**
+
+Mirrors the `JobHistoryPanel` pattern. File: `frontend/src/components/sidebar/ChatSessionsPanel.tsx`:
+
+```tsx
+/**
+ * Chat sessions panel for the sidebar.
+ *
+ * Lists persistent conversation sessions grouped by recency.
+ * Supports session switching, deletion, and new chat creation.
+ */
+
+import * as React from 'react';
+import { useAppState } from '@/hooks/useAppState';
+import { cn, formatTimeAgo } from '@/lib/utils';
+import { listConversations, deleteConversation, getConversationMessages, exportConversation } from '@/lib/api';
+import type { ChatSessionSummary, PersistedMessage } from '@/types/api';
+import type { ConversationMessage } from '@/hooks/useAppState';
+import { TrashIcon, PlusIcon, DownloadIcon } from '@/components/ui/icons';
+
+/** Mode badge for session items. */
+function ModeBadge({ mode }: { mode: string }) {
+  return (
+    <span className={cn(
+      'text-[9px] font-mono px-1.5 py-0.5 rounded',
+      mode === 'interactive'
+        ? 'bg-amber-500/10 text-amber-400 border border-amber-500/20'
+        : 'bg-primary/10 text-primary border border-primary/20'
+    )}>
+      {mode === 'interactive' ? 'Interactive' : 'Batch'}
+    </span>
+  );
+}
+
+/** Group sessions by relative date. */
+function groupByDate(sessions: ChatSessionSummary[]): Record<string, ChatSessionSummary[]> {
+  const now = new Date();
+  const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  const yesterday = new Date(today.getTime() - 86400000);
+  const weekAgo = new Date(today.getTime() - 7 * 86400000);
+
+  const groups: Record<string, ChatSessionSummary[]> = {};
+
+  for (const session of sessions) {
+    const date = new Date(session.created_at);
+    let group: string;
+    if (date >= today) group = 'Today';
+    else if (date >= yesterday) group = 'Yesterday';
+    else if (date >= weekAgo) group = 'Previous 7 Days';
+    else group = 'Older';
+
+    if (!groups[group]) groups[group] = [];
+    groups[group].push(session);
+  }
+
+  return groups;
+}
+
+interface ChatSessionsPanelProps {
+  onLoadSession: (
+    sessionId: string,
+    mode: 'batch' | 'interactive',
+    messages: ConversationMessage[],
+  ) => void;
+  onNewChat: () => void;
+  activeSessionId?: string | null;
+}
+
+export function ChatSessionsPanel({
+  onLoadSession,
+  onNewChat,
+  activeSessionId,
+}: ChatSessionsPanelProps) {
+  const { chatSessionsVersion, setChatSessions } = useAppState();
+  const [sessions, setSessions] = React.useState<ChatSessionSummary[]>([]);
+  const [isLoading, setIsLoading] = React.useState(true);
+  const [deletingId, setDeletingId] = React.useState<string | null>(null);
+
+  const loadSessions = React.useCallback(async () => {
+    try {
+      const data = await listConversations();
+      setSessions(data);
+      setChatSessions(data);
+    } catch (err) {
+      console.error('Failed to load chat sessions:', err);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [setChatSessions]);
+
+  React.useEffect(() => {
+    loadSessions();
+  }, [loadSessions, chatSessionsVersion]);
+
+  const handleDelete = async (e: React.MouseEvent, sessionId: string) => {
+    e.stopPropagation();
+    setDeletingId(sessionId);
+    try {
+      await deleteConversation(sessionId);
+      setSessions((prev) => prev.filter((s) => s.id !== sessionId));
+    } catch (err) {
+      console.error('Failed to delete session:', err);
+    } finally {
+      setDeletingId(null);
+    }
+  };
+
+  const handleExport = async (e: React.MouseEvent, sessionId: string) => {
+    e.stopPropagation();
+    try {
+      await exportConversation(sessionId);
+    } catch (err) {
+      console.error('Failed to export session:', err);
+    }
+  };
+
+  const handleSelect = async (session: ChatSessionSummary) => {
+    if (session.id === activeSessionId) return;
+    try {
+      const detail = await getConversationMessages(session.id);
+      const messages: ConversationMessage[] = detail.messages.map((m: PersistedMessage) => ({
+        id: m.id,
+        role: m.role === 'assistant' ? 'system' : m.role as 'user' | 'system',
+        content: m.content,
+        timestamp: new Date(m.created_at),
+        metadata: m.metadata ? m.metadata as ConversationMessage['metadata'] : undefined,
+      }));
+      onLoadSession(session.id, session.mode as 'batch' | 'interactive', messages);
+    } catch (err) {
+      console.error('Failed to load session:', err);
+    }
+  };
+
+  const grouped = groupByDate(sessions);
+  const groupOrder = ['Today', 'Yesterday', 'Previous 7 Days', 'Older'];
+
+  if (isLoading) {
+    return (
+      <div className="p-3 space-y-2">
+        <div className="h-4 w-24 bg-slate-800 rounded shimmer" />
+        <div className="h-10 bg-slate-800 rounded shimmer" />
+        <div className="h-10 bg-slate-800 rounded shimmer" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-3 space-y-3">
+      <div className="flex items-center justify-between">
+        <span className="text-xs font-medium text-slate-300">Chat Sessions</span>
+        <button
+          onClick={onNewChat}
+          className="flex items-center gap-1 px-2 py-1 text-[10px] font-medium rounded bg-primary/20 text-primary hover:bg-primary/30 transition-colors"
+          title="New chat"
+        >
+          <PlusIcon className="w-3 h-3" />
+          New Chat
+        </button>
+      </div>
+
+      <div className="space-y-3 max-h-[250px] overflow-y-auto scrollable">
+        {sessions.length === 0 ? (
+          <p className="text-xs text-slate-500 text-center py-4">
+            No conversations yet. Start typing to begin.
+          </p>
+        ) : (
+          groupOrder.map((group) => {
+            const items = grouped[group];
+            if (!items || items.length === 0) return null;
+            return (
+              <div key={group}>
+                <p className="text-[10px] font-mono text-slate-600 uppercase tracking-wider mb-1.5">
+                  {group}
+                </p>
+                <div className="space-y-1">
+                  {items.map((session) => (
+                    <div
+                      key={session.id}
+                      className={cn(
+                        'group relative w-full text-left p-2 rounded-md transition-colors cursor-pointer',
+                        'border border-transparent',
+                        activeSessionId === session.id
+                          ? 'bg-primary/10 border-primary/30'
+                          : 'hover:bg-slate-800/50'
+                      )}
+                      onClick={() => handleSelect(session)}
+                    >
+                      <div className="flex items-start justify-between gap-2">
+                        <div className="flex-1 min-w-0">
+                          <p className="text-xs text-slate-200 line-clamp-1">
+                            {session.title || 'New conversation...'}
+                          </p>
+                          <div className="flex items-center gap-1.5 mt-1">
+                            <ModeBadge mode={session.mode} />
+                            <span className="text-[10px] font-mono text-slate-500">
+                              {formatTimeAgo(session.updated_at || session.created_at)}
+                            </span>
+                          </div>
+                        </div>
+                        <div className="flex gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
+                          <button
+                            onClick={(e) => handleExport(e, session.id)}
+                            className="p-1 rounded hover:bg-slate-700 text-slate-500 hover:text-slate-300"
+                            title="Export"
+                          >
+                            <DownloadIcon className="w-3 h-3" />
+                          </button>
+                          <button
+                            onClick={(e) => handleDelete(e, session.id)}
+                            disabled={deletingId === session.id}
+                            className="p-1 rounded hover:bg-red-500/20 text-slate-500 hover:text-red-400"
+                            title="Delete"
+                          >
+                            <TrashIcon className="w-3 h-3" />
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            );
+          })
+        )}
+      </div>
+    </div>
+  );
+}
+```
+
+**Step 2: Integrate into `Sidebar.tsx`**
+
+Add import at top (line 11):
+```typescript
+import { ChatSessionsPanel } from '@/components/sidebar/ChatSessionsPanel';
+```
+
+Update `SidebarProps` interface to add callbacks:
+```typescript
+interface SidebarProps {
+  collapsed: boolean;
+  onToggle: () => void;
+  onSelectJob: (job: Job | null) => void;
+  activeJobId?: string;
+  onLoadSession: (sessionId: string, mode: 'batch' | 'interactive', messages: ConversationMessage[]) => void;
+  onNewChat: () => void;
+  activeSessionId?: string | null;
+}
+```
+
+Add import for ConversationMessage:
+```typescript
+import type { ConversationMessage } from '@/hooks/useAppState';
+```
+
+In the expanded content (between DataSourceSection and JobHistorySection, line 80):
+```tsx
+          {/* Chat Sessions Section */}
+          <div className="border-b border-slate-800">
+            <ChatSessionsPanel
+              onLoadSession={onLoadSession}
+              onNewChat={onNewChat}
+              activeSessionId={activeSessionId}
+            />
+          </div>
+```
+
+**Step 3: Check icons exist — add PlusIcon and DownloadIcon if missing**
+
+Check `frontend/src/components/ui/icons.tsx` for `PlusIcon` and `DownloadIcon`. If missing, add them following the existing SVG icon pattern.
+
+**Step 4: Verify TypeScript compiles**
+
+Run: `cd frontend && npx tsc --noEmit`
+Expected: No errors
+
+**Step 5: Commit**
+
+```bash
+git add frontend/src/components/sidebar/ChatSessionsPanel.tsx frontend/src/components/layout/Sidebar.tsx
+git commit -m "feat: add ChatSessionsPanel to sidebar with session listing and management"
+```
+
+---
+
+## Task 9: Frontend — CopyButton on Messages
+
+**Files:**
+- Modify: `frontend/src/components/command-center/messages.tsx`
+
+**Step 1: Add CopyButton component to `messages.tsx`**
+
+Add after the imports (after line 16):
+
+```tsx
+import { CopyIcon, CheckIcon } from '@/components/ui/icons';
+
+/** Copy-to-clipboard button with brief checkmark feedback. */
+function CopyButton({ text }: { text: string }) {
+  const [copied, setCopied] = React.useState(false);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      console.error('Failed to copy to clipboard');
+    }
+  };
+
+  return (
+    <button
+      onClick={handleCopy}
+      className="absolute top-2 right-2 p-1 rounded opacity-0 group-hover:opacity-100 transition-opacity bg-slate-800/80 hover:bg-slate-700 text-slate-400 hover:text-slate-200"
+      title="Copy to clipboard"
+    >
+      {copied ? (
+        <CheckIcon className="w-3.5 h-3.5 text-green-400" />
+      ) : (
+        <CopyIcon className="w-3.5 h-3.5" />
+      )}
+    </button>
+  );
+}
+```
+
+Add `import * as React from 'react';` at the top if not already present.
+
+**Step 2: Add CopyButton to SystemMessage**
+
+Wrap the existing content div with `group` class and add CopyButton. Modify `SystemMessage` (lines 19-38):
+
+```tsx
+export function SystemMessage({ message }: { message: ConversationMessage }) {
+  return (
+    <div className="flex gap-3 animate-fade-in-up">
+      <div className="flex-shrink-0 w-8 h-8 rounded-lg bg-gradient-to-br from-cyan-500/20 to-cyan-600/20 border border-cyan-500/30 flex items-center justify-center">
+        <PackageIcon className="w-4 h-4 text-cyan-400" />
+      </div>
+
+      <div className="flex-1 space-y-2 relative group">
+        <div className="message-system prose prose-invert max-w-none prose-sm prose-p:leading-relaxed prose-pre:bg-slate-800/50 prose-pre:border prose-pre:border-slate-700/50">
+          <ReactMarkdown remarkPlugins={[remarkGfm]}>
+            {message.content}
+          </ReactMarkdown>
+        </div>
+        <CopyButton text={message.content} />
+
+        <span className="text-[10px] font-mono text-slate-500">
+          {formatRelativeTime(message.timestamp)}
+        </span>
+      </div>
+    </div>
+  );
+}
+```
+
+**Step 3: Add CopyButton to UserMessage**
+
+```tsx
+export function UserMessage({ message }: { message: ConversationMessage }) {
+  return (
+    <div className="flex gap-3 justify-end animate-fade-in-up">
+      <div className="flex-1 space-y-2 flex flex-col items-end relative group">
+        <div className="message-user">
+          <p className="text-sm whitespace-pre-wrap">{message.content}</p>
+        </div>
+        <CopyButton text={message.content} />
+
+        <span className="text-[10px] font-mono text-slate-500">
+          {formatRelativeTime(message.timestamp)}
+        </span>
+      </div>
+    </div>
+  );
+}
+```
+
+**Step 4: Verify TypeScript compiles and check icons**
+
+Check that `CopyIcon` and `CheckIcon` exist in `frontend/src/components/ui/icons.tsx`. If missing, add:
+
+```tsx
+export function CopyIcon({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+      <path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1" />
+    </svg>
+  );
+}
+
+export function CheckIcon({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <polyline points="20 6 9 17 4 12" />
+    </svg>
+  );
+}
+```
+
+Run: `cd frontend && npx tsc --noEmit`
+Expected: No errors
+
+**Step 5: Commit**
+
+```bash
+git add frontend/src/components/command-center/messages.tsx frontend/src/components/ui/icons.tsx
+git commit -m "feat: add copy-to-clipboard button on chat message bubbles"
+```
+
+---
+
+## Task 10: Frontend — Visual Timeline Minimap
+
+**Files:**
+- Create: `frontend/src/components/command-center/ChatTimeline.tsx`
+- Modify: `frontend/src/components/CommandCenter.tsx` (integrate timeline + data-message-id)
+
+**Step 1: Create `ChatTimeline.tsx`**
+
+```tsx
+/**
+ * Visual timeline minimap for chat navigation.
+ *
+ * Thin vertical line with color-coded dots representing messages.
+ * Syncs with scroll position via IntersectionObserver.
+ * Click a dot to scroll to the corresponding message.
+ */
+
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+import type { ConversationMessage } from '@/hooks/useAppState';
+
+/** Map message to timeline dot color. */
+function getDotColor(message: ConversationMessage): string {
+  if (message.metadata?.action === 'error') return 'bg-red-400';
+  if (message.metadata?.action) return 'bg-amber-400'; // artifact
+  if (message.role === 'user') return 'bg-slate-400';
+  return 'bg-cyan-400'; // assistant
+}
+
+interface ChatTimelineProps {
+  messages: ConversationMessage[];
+  scrollContainerRef: React.RefObject<HTMLDivElement | null>;
+}
+
+export function ChatTimeline({ messages, scrollContainerRef }: ChatTimelineProps) {
+  const [visibleIds, setVisibleIds] = React.useState<Set<string>>(new Set());
+
+  // Observe which messages are in the viewport
+  React.useEffect(() => {
+    const container = scrollContainerRef.current;
+    if (!container) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        setVisibleIds((prev) => {
+          const next = new Set(prev);
+          for (const entry of entries) {
+            const id = entry.target.getAttribute('data-message-id');
+            if (!id) continue;
+            if (entry.isIntersecting) next.add(id);
+            else next.delete(id);
+          }
+          return next;
+        });
+      },
+      { root: container, threshold: 0.3 },
+    );
+
+    const elements = container.querySelectorAll('[data-message-id]');
+    elements.forEach((el) => observer.observe(el));
+
+    return () => observer.disconnect();
+  }, [scrollContainerRef, messages.length]);
+
+  const handleDotClick = (messageId: string) => {
+    const el = scrollContainerRef.current?.querySelector(
+      `[data-message-id="${messageId}"]`,
+    );
+    el?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+  };
+
+  if (messages.length === 0) return null;
+
+  return (
+    <div className="relative w-4 flex-shrink-0 flex flex-col items-center py-6">
+      {/* Vertical line */}
+      <div className="absolute top-6 bottom-6 w-px bg-slate-800" />
+
+      {/* Dots */}
+      <div className="relative flex flex-col justify-between h-full w-full items-center">
+        {messages.map((msg) => {
+          const isVisible = visibleIds.has(msg.id);
+          return (
+            <button
+              key={msg.id}
+              onClick={() => handleDotClick(msg.id)}
+              className={cn(
+                'relative z-10 rounded-full transition-all duration-200 cursor-pointer',
+                getDotColor(msg),
+                isVisible ? 'w-2.5 h-2.5 opacity-100 shadow-lg' : 'w-1.5 h-1.5 opacity-50',
+              )}
+              title={`${msg.role}: ${msg.content.slice(0, 40)}...`}
+            />
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+```
+
+**Step 2: Integrate into `CommandCenter.tsx`**
+
+Add import (after line 33):
+```tsx
+import { ChatTimeline } from '@/components/command-center/ChatTimeline';
+```
+
+Add a ref for the scroll container. After `messagesEndRef` (line 103):
+```tsx
+  const scrollContainerRef = React.useRef<HTMLDivElement>(null);
+```
+
+Modify the messages area (line 478) to include `ref` and timeline:
+```tsx
+      {/* Messages area with timeline */}
+      <div className="flex flex-1 overflow-hidden">
+        <div ref={scrollContainerRef} className="command-messages-shell flex-1 overflow-y-auto scrollable p-6">
+```
+
+Add `data-message-id` to each message element. In the conversation map (line 483), wrap each message:
+```tsx
+            {conversation.map((message) => (
+              <div key={message.id} data-message-id={message.id}>
+                {message.metadata?.action === 'complete' ? (
+```
+
+Remove the `key={message.id}` from the inner elements since it's now on the wrapper div.
+
+After the closing `</div>` of the scroll container, add the timeline:
+```tsx
+        {/* Visual Timeline */}
+        {conversation.length > 3 && (
+          <ChatTimeline
+            messages={conversation}
+            scrollContainerRef={scrollContainerRef}
+          />
+        )}
+      </div>
+```
+
+**Step 3: Verify TypeScript compiles**
+
+Run: `cd frontend && npx tsc --noEmit`
+Expected: No errors
+
+**Step 4: Commit**
+
+```bash
+git add frontend/src/components/command-center/ChatTimeline.tsx frontend/src/components/CommandCenter.tsx
+git commit -m "feat: add visual timeline minimap for chat navigation"
+```
+
+---
+
+## Task 11: Integration — Wire Sidebar to CommandCenter
+
+**Files:**
+- Modify: `frontend/src/components/CommandCenter.tsx` (add session loading handler)
+- Modify: `frontend/src/App.tsx` (pass callbacks through Sidebar)
+
+**Step 1: Add session loading to CommandCenter**
+
+Add a `handleLoadSession` callback in `CommandCenter` that:
+1. Sets `interactiveShipping` from session mode
+2. Clears current conversation
+3. Populates conversation from loaded messages
+4. Calls `conv.loadSession()`
+5. Refreshes chat sessions list
+
+```tsx
+  const handleLoadSession = React.useCallback(async (
+    sessionId: string,
+    mode: 'batch' | 'interactive',
+    messages: ConversationMessage[],
+  ) => {
+    // Set mode BEFORE rendering to prevent flicker
+    setInteractiveShipping(mode === 'interactive');
+
+    // Clear current state
+    clearConversation();
+    setPreview(null);
+    setCurrentJobId(null);
+    setExecutingJobId(null);
+
+    // Populate conversation from loaded messages
+    for (const msg of messages) {
+      addMessage(msg);
+    }
+
+    // Connect to the session
+    await conv.loadSession(sessionId, mode, messages);
+    setConversationSessionId(sessionId);
+  }, [conv, setInteractiveShipping, clearConversation, addMessage, setConversationSessionId]);
+
+  const handleNewChat = React.useCallback(async () => {
+    await conv.startNewChat();
+    clearConversation();
+    setPreview(null);
+    setCurrentJobId(null);
+    setExecutingJobId(null);
+    setConversationSessionId(null);
+    refreshChatSessions();
+  }, [conv, clearConversation, setConversationSessionId, refreshChatSessions]);
+```
+
+Note: `refreshChatSessions` needs to be added to the destructured values from `useAppState()`.
+
+**Step 2: Pass callbacks through App.tsx to Sidebar**
+
+In `App.tsx`, pass `handleLoadSession` and `handleNewChat` from `CommandCenter` to `Sidebar`. This requires lifting the callbacks up or using context. The simplest approach: pass them via props from `App.tsx` through `Sidebar`.
+
+Look at `App.tsx` to see how Sidebar and CommandCenter are connected, then wire the props through.
+
+**Step 3: Verify TypeScript compiles and test manually**
+
+Run: `cd frontend && npx tsc --noEmit`
+Expected: No errors
+
+**Step 4: Commit**
+
+```bash
+git add frontend/src/components/CommandCenter.tsx frontend/src/App.tsx frontend/src/components/layout/Sidebar.tsx
+git commit -m "feat: wire sidebar session loading to CommandCenter"
+```
+
+---
+
+## Task 12: Title Generation — Background Haiku Task
+
+**Files:**
+- Modify: `src/api/routes/conversations.py` (add title generation after first response)
+
+**Step 1: Write test**
+
+Add to `tests/services/test_conversation_persistence_service.py`:
+
+```python
+class TestTitleGeneration:
+    def test_title_updates_after_generation(self, svc, db_session):
+        svc.create_session(session_id="s1", mode="batch")
+        svc.save_message("s1", "user", "Ship all CA orders via Ground")
+        svc.save_message("s1", "assistant", "I'll help ship those orders.")
+        svc.update_session_title("s1", "Ground Batch - CA Orders")
+        from src.db.models import ConversationSession
+        sess = db_session.query(ConversationSession).get("s1")
+        assert sess.title == "Ground Batch - CA Orders"
+```
+
+**Step 2: Add title generation function to `conversations.py`**
+
+Add a background task function:
+
+```python
+async def _generate_session_title(session_id: str) -> None:
+    """Generate a session title via a lightweight Haiku call.
+
+    Fire-and-forget background task. Runs after the first assistant
+    response is saved. Updates the DB title field.
+    """
+    try:
+        svc = _get_persistence_service()
+        result = svc.get_session_with_messages(session_id, limit=2)
+        if result is None or len(result["messages"]) < 2:
+            return
+
+        # Already has a title — skip
+        if result["session"].get("title"):
+            return
+
+        user_msg = result["messages"][0]["content"][:200]
+        assistant_msg = result["messages"][1]["content"][:200]
+
+        from anthropic import AsyncAnthropic
+
+        client = AsyncAnthropic()
+        response = await client.messages.create(
+            model="claude-haiku-4-5-20251001",
+            max_tokens=30,
+            messages=[{
+                "role": "user",
+                "content": (
+                    f"Generate a concise 3-6 word title for this shipping conversation. "
+                    f"Return ONLY the title, no quotes or explanation.\n\n"
+                    f"User: {user_msg}\n"
+                    f"Assistant: {assistant_msg}"
+                ),
+            }],
+        )
+
+        title = response.content[0].text.strip()[:255]
+        if title:
+            svc.update_session_title(session_id, title)
+            logger.info("Generated title for session %s: %s", session_id, title)
+
+    except Exception as e:
+        logger.warning("Title generation failed for session %s: %s", session_id, e)
+```
+
+**Step 3: Trigger title generation after first assistant response**
+
+In `_process_agent_message`, after persisting the first assistant message, check if this is the first response and fire the background task:
+
+```python
+    # Check if this is the first assistant message — generate title
+    try:
+        persistence = _get_persistence_service()
+        result = persistence.get_session_with_messages(session_id, limit=3)
+        if result and not result["session"].get("title"):
+            assistant_count = sum(1 for m in result["messages"] if m["role"] == "assistant")
+            if assistant_count == 1:
+                asyncio.create_task(_generate_session_title(session_id))
+    except Exception:
+        pass  # Title generation is best-effort
+```
+
+**Step 4: Run tests**
+
+Run: `pytest tests/services/test_conversation_persistence_service.py -v -k title`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add src/api/routes/conversations.py tests/services/test_conversation_persistence_service.py
+git commit -m "feat: add background Haiku title generation for chat sessions"
+```
+
+---
+
+## Task 13: Run Full Test Suite
+
+**Step 1: Run all existing tests (excluding known hangers)**
+
+Run: `pytest -x -k "not stream and not sse and not progress and not test_stream_endpoint_exists" --timeout=30`
+Expected: All pass (existing tests should not be broken by new DB tables)
+
+**Step 2: Run new tests specifically**
+
+Run: `pytest tests/db/test_conversation_models.py tests/services/test_conversation_persistence_service.py tests/api/test_conversations_persistence.py tests/api/test_conversation_schemas.py tests/orchestrator/agent/test_system_prompt_resume.py -v`
+Expected: All PASS
+
+**Step 3: Run frontend type check**
+
+Run: `cd frontend && npx tsc --noEmit`
+Expected: No errors
+
+**Step 4: Commit any fixes**
+
+```bash
+git add -A
+git commit -m "fix: resolve test/type issues from chat persistence integration"
+```
+
+---
+
+## Summary of All Commits
+
+| # | Commit Message | Files |
+|---|---------------|-------|
+| 1 | `feat: add ConversationSession and ConversationMessage DB models` | models.py, test |
+| 2 | `feat: add ConversationPersistenceService for chat history CRUD` | service, test |
+| 3 | `feat: add Pydantic schemas for chat session persistence` | schemas, test |
+| 4 | `feat: add conversation persistence API endpoints` | routes, test |
+| 5 | `feat: add prior conversation injection to system prompt` | system_prompt, test |
+| 6 | `feat: add chat session persistence types and API client` | types, api.ts |
+| 7 | `feat: add chat session state and hooks` | useAppState, useConversation |
+| 8 | `feat: add ChatSessionsPanel to sidebar` | panel, sidebar |
+| 9 | `feat: add copy-to-clipboard on messages` | messages, icons |
+| 10 | `feat: add visual timeline minimap` | ChatTimeline, CommandCenter |
+| 11 | `feat: wire sidebar session loading to CommandCenter` | CommandCenter, App |
+| 12 | `feat: add background Haiku title generation` | routes, test |
+| 13 | `fix: resolve integration issues` | any fixes |

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,11 +5,13 @@
  * with precision engineering controls.
  */
 
-import { CommandCenter } from '@/components/CommandCenter';
+import * as React from 'react';
+import { CommandCenter, type CommandCenterHandle } from '@/components/CommandCenter';
 import { Sidebar } from '@/components/layout/Sidebar';
 import { Header } from '@/components/layout/Header';
 import { SettingsFlyout } from '@/components/settings/SettingsFlyout';
 import { useAppState, AppStateProvider } from '@/hooks/useAppState';
+import type { ConversationMessage } from '@/hooks/useAppState';
 
 function AppContent() {
   const {
@@ -17,7 +19,21 @@ function AppContent() {
     setActiveJob,
     sidebarCollapsed,
     setSidebarCollapsed,
+    conversationSessionId,
   } = useAppState();
+
+  const commandCenterRef = React.useRef<CommandCenterHandle>(null);
+
+  const handleLoadSession = React.useCallback(
+    (sessionId: string, mode: 'batch' | 'interactive', messages: ConversationMessage[]) => {
+      commandCenterRef.current?.loadSession(sessionId, mode, messages);
+    },
+    [],
+  );
+
+  const handleNewChat = React.useCallback(() => {
+    commandCenterRef.current?.newChat();
+  }, []);
 
   return (
     <div className="h-screen flex flex-col bg-background overflow-hidden">
@@ -30,11 +46,14 @@ function AppContent() {
           onToggle={() => setSidebarCollapsed(!sidebarCollapsed)}
           onSelectJob={setActiveJob}
           activeJobId={activeJob?.id}
+          onLoadSession={handleLoadSession}
+          onNewChat={handleNewChat}
+          activeSessionId={conversationSessionId}
         />
 
         {/* Main content - Conversational command interface */}
         <main className="flex-1 flex flex-col overflow-hidden">
-          <CommandCenter activeJob={activeJob} />
+          <CommandCenter ref={commandCenterRef} activeJob={activeJob} />
         </main>
 
         {/* Settings flyout - Overlays on desktop, pushes on mobile */}

--- a/frontend/src/components/CommandCenter.tsx
+++ b/frontend/src/components/CommandCenter.tsx
@@ -31,6 +31,7 @@ import { PaperlessCard } from '@/components/command-center/PaperlessCard';
 import { PaperlessUploadCard } from '@/components/command-center/PaperlessUploadCard';
 import { TrackingCard } from '@/components/command-center/TrackingCard';
 import { ContactCard } from '@/components/command-center/ContactCard';
+import { ChatTimeline } from '@/components/command-center/ChatTimeline';
 import {
   ActiveSourceBanner,
   InteractiveModeBanner,
@@ -101,6 +102,7 @@ export function CommandCenter({ activeJob }: CommandCenterProps) {
   }, []);
 
   const messagesEndRef = React.useRef<HTMLDivElement>(null);
+  const scrollContainerRef = React.useRef<HTMLDivElement>(null);
   const lastCommandRef = React.useRef<string>('');
   const lastJobNameRef = React.useRef<string>('');
   const prevInteractiveRef = React.useRef(interactiveShipping);
@@ -474,15 +476,17 @@ export function CommandCenter({ activeJob }: CommandCenterProps) {
   return (
     <div className={cn('flex flex-col h-full', interactiveShipping && 'command-center--interactive')}>
       {interactiveShipping ? <InteractiveModeBanner /> : <ActiveSourceBanner />}
-      {/* Messages area */}
-      <div className="command-messages-shell flex-1 overflow-y-auto scrollable p-6">
+      {/* Messages area with timeline */}
+      <div className="flex flex-1 overflow-hidden">
+        <div ref={scrollContainerRef} className="command-messages-shell flex-1 overflow-y-auto scrollable p-6">
         {conversation.length === 0 && !preview && !executingJobId ? (
           <WelcomeMessage onExampleClick={(text) => setInputValue(text)} interactiveShipping={interactiveShipping} />
         ) : (
           <div className="max-w-3xl mx-auto space-y-6">
             {conversation.map((message) => (
-              message.metadata?.action === 'complete' ? (
-                <div key={message.id} className="pl-11">
+              <div key={message.id} data-message-id={message.id}>
+              {message.metadata?.action === 'complete' ? (
+                <div className="pl-11">
                   <CompletionArtifact
                     message={message}
                     onViewLabels={(jobId) => {
@@ -495,7 +499,7 @@ export function CommandCenter({ activeJob }: CommandCenterProps) {
                   />
                 </div>
               ) : message.metadata?.action === 'pickup_preview' && message.metadata.pickupPreview ? (
-                <div key={message.id} className="pl-11">
+                <div className="pl-11">
                   <PickupPreviewCard
                     data={message.metadata.pickupPreview}
                     onConfirm={async () => {
@@ -515,19 +519,19 @@ export function CommandCenter({ activeJob }: CommandCenterProps) {
                   />
                 </div>
               ) : message.metadata?.action === 'pickup_result' && message.metadata.pickup ? (
-                <div key={message.id} className="pl-11">
+                <div className="pl-11">
                   <PickupCompletionCard data={message.metadata.pickup} />
                 </div>
               ) : message.metadata?.action === 'location_result' && message.metadata.location ? (
-                <div key={message.id} className="pl-11">
+                <div className="pl-11">
                   <LocationCard data={message.metadata.location} />
                 </div>
               ) : message.metadata?.action === 'landed_cost_result' && message.metadata.landedCost ? (
-                <div key={message.id} className="pl-11">
+                <div className="pl-11">
                   <LandedCostCard data={message.metadata.landedCost} />
                 </div>
               ) : message.metadata?.action === 'paperless_upload_prompt' && message.metadata.paperlessUpload ? (
-                <div key={message.id} className="pl-11">
+                <div className="pl-11">
                   <PaperlessUploadCard
                     data={message.metadata.paperlessUpload}
                     sessionId={conv.sessionId ?? ''}
@@ -542,15 +546,15 @@ export function CommandCenter({ activeJob }: CommandCenterProps) {
                   />
                 </div>
               ) : message.metadata?.action === 'paperless_result' && message.metadata.paperless ? (
-                <div key={message.id} className="pl-11">
+                <div className="pl-11">
                   <PaperlessCard data={message.metadata.paperless} />
                 </div>
               ) : message.metadata?.action === 'tracking_result' && message.metadata.tracking ? (
-                <div key={message.id} className="pl-11">
+                <div className="pl-11">
                   <TrackingCard data={message.metadata.tracking} />
                 </div>
               ) : message.metadata?.action === 'contact_saved' && message.metadata.contactSaved ? (
-                <div key={message.id} className="pl-11">
+                <div className="pl-11">
                   <ContactCard
                     data={message.metadata.contactSaved}
                     onEdit={() => {
@@ -560,10 +564,11 @@ export function CommandCenter({ activeJob }: CommandCenterProps) {
                   />
                 </div>
               ) : message.role === 'user' ? (
-                <UserMessage key={message.id} message={message} />
+                <UserMessage message={message} />
               ) : (
-                <SystemMessage key={message.id} message={message} />
-              )
+                <SystemMessage message={message} />
+              )}
+              </div>
             ))}
 
             {/* Preview card */}
@@ -707,6 +712,15 @@ export function CommandCenter({ activeJob }: CommandCenterProps) {
 
             <div ref={messagesEndRef} />
           </div>
+        )}
+        </div>
+
+        {/* Visual Timeline */}
+        {conversation.length > 3 && (
+          <ChatTimeline
+            messages={conversation}
+            scrollContainerRef={scrollContainerRef}
+          />
         )}
       </div>
 

--- a/frontend/src/components/command-center/ChatTimeline.tsx
+++ b/frontend/src/components/command-center/ChatTimeline.tsx
@@ -1,0 +1,90 @@
+/**
+ * Visual timeline minimap for chat navigation.
+ *
+ * Thin vertical line with color-coded dots representing messages.
+ * Syncs with scroll position via IntersectionObserver.
+ * Click a dot to scroll to the corresponding message.
+ */
+
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+import type { ConversationMessage } from '@/hooks/useAppState';
+
+/** Map message to timeline dot color. */
+function getDotColor(message: ConversationMessage): string {
+  if (message.metadata?.action === 'error') return 'bg-red-400';
+  if (message.metadata?.action) return 'bg-amber-400'; // artifact
+  if (message.role === 'user') return 'bg-slate-400';
+  return 'bg-cyan-400'; // assistant
+}
+
+interface ChatTimelineProps {
+  messages: ConversationMessage[];
+  scrollContainerRef: React.RefObject<HTMLDivElement | null>;
+}
+
+export function ChatTimeline({ messages, scrollContainerRef }: ChatTimelineProps) {
+  const [visibleIds, setVisibleIds] = React.useState<Set<string>>(new Set());
+
+  // Observe which messages are in the viewport
+  React.useEffect(() => {
+    const container = scrollContainerRef.current;
+    if (!container) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        setVisibleIds((prev) => {
+          const next = new Set(prev);
+          for (const entry of entries) {
+            const id = entry.target.getAttribute('data-message-id');
+            if (!id) continue;
+            if (entry.isIntersecting) next.add(id);
+            else next.delete(id);
+          }
+          return next;
+        });
+      },
+      { root: container, threshold: 0.3 },
+    );
+
+    const elements = container.querySelectorAll('[data-message-id]');
+    elements.forEach((el) => observer.observe(el));
+
+    return () => observer.disconnect();
+  }, [scrollContainerRef, messages.length]);
+
+  const handleDotClick = (messageId: string) => {
+    const el = scrollContainerRef.current?.querySelector(
+      `[data-message-id="${messageId}"]`,
+    );
+    el?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+  };
+
+  if (messages.length === 0) return null;
+
+  return (
+    <div className="relative w-4 flex-shrink-0 flex flex-col items-center py-6">
+      {/* Vertical line */}
+      <div className="absolute top-6 bottom-6 w-px bg-slate-800" />
+
+      {/* Dots */}
+      <div className="relative flex flex-col justify-between h-full w-full items-center">
+        {messages.map((msg) => {
+          const isVisible = visibleIds.has(msg.id);
+          return (
+            <button
+              key={msg.id}
+              onClick={() => handleDotClick(msg.id)}
+              className={cn(
+                'relative z-10 rounded-full transition-all duration-200 cursor-pointer',
+                getDotColor(msg),
+                isVisible ? 'w-2.5 h-2.5 opacity-100 shadow-lg' : 'w-1.5 h-1.5 opacity-50',
+              )}
+              title={`${msg.role}: ${msg.content.slice(0, 40)}...`}
+            />
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/command-center/messages.tsx
+++ b/frontend/src/components/command-center/messages.tsx
@@ -7,13 +7,43 @@
  * WelcomeMessage for onboarding and example commands.
  */
 
+import * as React from 'react';
 import { useAppState, type ConversationMessage } from '@/hooks/useAppState';
 import { cn, formatRelativeTime } from '@/lib/utils';
 import { Package } from 'lucide-react';
-import { PackageIcon, GearIcon, HardDriveIcon } from '@/components/ui/icons';
+import { PackageIcon, GearIcon, HardDriveIcon, CopyIcon, CheckIcon } from '@/components/ui/icons';
 import { ShopifyIcon } from '@/components/ui/brand-icons';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
+
+/** Copy-to-clipboard button with brief checkmark feedback. */
+function CopyButton({ text }: { text: string }) {
+  const [copied, setCopied] = React.useState(false);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      console.error('Failed to copy to clipboard');
+    }
+  };
+
+  return (
+    <button
+      onClick={handleCopy}
+      className="absolute top-2 right-2 p-1 rounded opacity-0 group-hover:opacity-100 transition-opacity bg-slate-800/80 hover:bg-slate-700 text-slate-400 hover:text-slate-200"
+      title="Copy to clipboard"
+    >
+      {copied ? (
+        <CheckIcon className="w-3.5 h-3.5 text-green-400" />
+      ) : (
+        <CopyIcon className="w-3.5 h-3.5" />
+      )}
+    </button>
+  );
+}
 
 /** System-generated chat message with avatar. */
 export function SystemMessage({ message }: { message: ConversationMessage }) {
@@ -23,12 +53,13 @@ export function SystemMessage({ message }: { message: ConversationMessage }) {
         <PackageIcon className="w-4 h-4 text-cyan-400" />
       </div>
 
-      <div className="flex-1 space-y-2">
+      <div className="flex-1 space-y-2 relative group">
         <div className="message-system prose prose-invert max-w-none prose-sm prose-p:leading-relaxed prose-pre:bg-slate-800/50 prose-pre:border prose-pre:border-slate-700/50">
           <ReactMarkdown remarkPlugins={[remarkGfm]}>
             {message.content}
           </ReactMarkdown>
         </div>
+        <CopyButton text={message.content} />
 
         <span className="text-[10px] font-mono text-slate-500">
           {formatRelativeTime(message.timestamp)}
@@ -42,10 +73,11 @@ export function SystemMessage({ message }: { message: ConversationMessage }) {
 export function UserMessage({ message }: { message: ConversationMessage }) {
   return (
     <div className="flex gap-3 justify-end animate-fade-in-up">
-      <div className="flex-1 space-y-2 flex flex-col items-end">
+      <div className="flex-1 space-y-2 flex flex-col items-end relative group">
         <div className="message-user">
           <p className="text-sm whitespace-pre-wrap">{message.content}</p>
         </div>
+        <CopyButton text={message.content} />
 
         <span className="text-[10px] font-mono text-slate-500">
           {formatRelativeTime(message.timestamp)}

--- a/frontend/src/components/command-center/messages.tsx
+++ b/frontend/src/components/command-center/messages.tsx
@@ -18,15 +18,17 @@ import remarkGfm from 'remark-gfm';
 
 /** Copy-to-clipboard button with brief checkmark feedback. */
 function CopyButton({ text }: { text: string }) {
-  const [copied, setCopied] = React.useState(false);
+  const [state, setState] = React.useState<'idle' | 'copied' | 'error'>('idle');
 
   const handleCopy = async () => {
     try {
       await navigator.clipboard.writeText(text);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 1500);
-    } catch {
-      console.error('Failed to copy to clipboard');
+      setState('copied');
+      setTimeout(() => setState('idle'), 1500);
+    } catch (err) {
+      console.error('Failed to copy to clipboard:', err);
+      setState('error');
+      setTimeout(() => setState('idle'), 2000);
     }
   };
 
@@ -34,10 +36,12 @@ function CopyButton({ text }: { text: string }) {
     <button
       onClick={handleCopy}
       className="absolute top-2 right-2 p-1 rounded opacity-0 group-hover:opacity-100 transition-opacity bg-slate-800/80 hover:bg-slate-700 text-slate-400 hover:text-slate-200"
-      title="Copy to clipboard"
+      title={state === 'error' ? 'Copy failed' : 'Copy to clipboard'}
     >
-      {copied ? (
+      {state === 'copied' ? (
         <CheckIcon className="w-3.5 h-3.5 text-green-400" />
+      ) : state === 'error' ? (
+        <span className="text-red-400 text-[10px] font-medium px-0.5">!</span>
       ) : (
         <CopyIcon className="w-3.5 h-3.5" />
       )}

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -9,15 +9,20 @@ import { ChevronIcon, HardDriveIcon, HistoryIcon } from '@/components/ui/icons';
 import { ShopifyIcon, DataSourceIcon } from '@/components/ui/brand-icons';
 import { DataSourceSection } from '@/components/sidebar/DataSourcePanel';
 import { JobHistorySection } from '@/components/sidebar/JobHistoryPanel';
+import { ChatSessionsPanel } from '@/components/sidebar/ChatSessionsPanel';
+import type { ConversationMessage } from '@/hooks/useAppState';
 
 interface SidebarProps {
   collapsed: boolean;
   onToggle: () => void;
   onSelectJob: (job: Job | null) => void;
   activeJobId?: string;
+  onLoadSession?: (sessionId: string, mode: 'batch' | 'interactive', messages: ConversationMessage[]) => void;
+  onNewChat?: () => void;
+  activeSessionId?: string | null;
 }
 
-export function Sidebar({ collapsed, onToggle, onSelectJob, activeJobId }: SidebarProps) {
+export function Sidebar({ collapsed, onToggle, onSelectJob, activeJobId, onLoadSession, onNewChat, activeSessionId }: SidebarProps) {
   const { activeSourceType, activeSourceInfo } = useAppState();
 
   const hasDataSource = activeSourceType !== null;
@@ -76,6 +81,17 @@ export function Sidebar({ collapsed, onToggle, onSelectJob, activeJobId }: Sideb
           <div className="border-b border-slate-800">
             <DataSourceSection />
           </div>
+
+          {/* Chat Sessions Section */}
+          {onLoadSession && onNewChat && (
+            <div className="border-b border-slate-800">
+              <ChatSessionsPanel
+                onLoadSession={onLoadSession}
+                onNewChat={onNewChat}
+                activeSessionId={activeSessionId}
+              />
+            </div>
+          )}
 
           {/* Job History Section */}
           <div>

--- a/frontend/src/components/sidebar/ChatSessionsPanel.tsx
+++ b/frontend/src/components/sidebar/ChatSessionsPanel.tsx
@@ -1,0 +1,223 @@
+/**
+ * Chat sessions panel for the sidebar.
+ *
+ * Lists persistent conversation sessions grouped by recency.
+ * Supports session switching, deletion, and new chat creation.
+ */
+
+import * as React from 'react';
+import { useAppState } from '@/hooks/useAppState';
+import { cn, formatTimeAgo } from '@/lib/utils';
+import { listConversations, deleteConversation, getConversationMessages, exportConversation } from '@/lib/api';
+import type { ChatSessionSummary, PersistedMessage } from '@/types/api';
+import type { ConversationMessage } from '@/hooks/useAppState';
+import { TrashIcon, PlusIcon, DownloadIcon } from '@/components/ui/icons';
+
+/** Mode badge for session items. */
+function ModeBadge({ mode }: { mode: string }) {
+  return (
+    <span className={cn(
+      'text-[9px] font-mono px-1.5 py-0.5 rounded',
+      mode === 'interactive'
+        ? 'bg-amber-500/10 text-amber-400 border border-amber-500/20'
+        : 'bg-primary/10 text-primary border border-primary/20'
+    )}>
+      {mode === 'interactive' ? 'Interactive' : 'Batch'}
+    </span>
+  );
+}
+
+/** Group sessions by relative date. */
+function groupByDate(sessions: ChatSessionSummary[]): Record<string, ChatSessionSummary[]> {
+  const now = new Date();
+  const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  const yesterday = new Date(today.getTime() - 86400000);
+  const weekAgo = new Date(today.getTime() - 7 * 86400000);
+
+  const groups: Record<string, ChatSessionSummary[]> = {};
+
+  for (const session of sessions) {
+    const date = new Date(session.created_at);
+    let group: string;
+    if (date >= today) group = 'Today';
+    else if (date >= yesterday) group = 'Yesterday';
+    else if (date >= weekAgo) group = 'Previous 7 Days';
+    else group = 'Older';
+
+    if (!groups[group]) groups[group] = [];
+    groups[group].push(session);
+  }
+
+  return groups;
+}
+
+interface ChatSessionsPanelProps {
+  onLoadSession: (
+    sessionId: string,
+    mode: 'batch' | 'interactive',
+    messages: ConversationMessage[],
+  ) => void;
+  onNewChat: () => void;
+  activeSessionId?: string | null;
+}
+
+export function ChatSessionsPanel({
+  onLoadSession,
+  onNewChat,
+  activeSessionId,
+}: ChatSessionsPanelProps) {
+  const { chatSessionsVersion, setChatSessions } = useAppState();
+  const [sessions, setSessions] = React.useState<ChatSessionSummary[]>([]);
+  const [isLoading, setIsLoading] = React.useState(true);
+  const [deletingId, setDeletingId] = React.useState<string | null>(null);
+
+  const loadSessions = React.useCallback(async () => {
+    try {
+      const data = await listConversations();
+      setSessions(data);
+      setChatSessions(data);
+    } catch (err) {
+      console.error('Failed to load chat sessions:', err);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [setChatSessions]);
+
+  React.useEffect(() => {
+    loadSessions();
+  }, [loadSessions, chatSessionsVersion]);
+
+  const handleDelete = async (e: React.MouseEvent, sessionId: string) => {
+    e.stopPropagation();
+    setDeletingId(sessionId);
+    try {
+      await deleteConversation(sessionId);
+      setSessions((prev) => prev.filter((s) => s.id !== sessionId));
+    } catch (err) {
+      console.error('Failed to delete session:', err);
+    } finally {
+      setDeletingId(null);
+    }
+  };
+
+  const handleExport = async (e: React.MouseEvent, sessionId: string) => {
+    e.stopPropagation();
+    try {
+      await exportConversation(sessionId);
+    } catch (err) {
+      console.error('Failed to export session:', err);
+    }
+  };
+
+  const handleSelect = async (session: ChatSessionSummary) => {
+    if (session.id === activeSessionId) return;
+    try {
+      const detail = await getConversationMessages(session.id);
+      const messages: ConversationMessage[] = detail.messages.map((m: PersistedMessage) => ({
+        id: m.id,
+        role: m.role === 'assistant' ? 'system' : m.role as 'user' | 'system',
+        content: m.content,
+        timestamp: new Date(m.created_at),
+        metadata: m.metadata ? m.metadata as ConversationMessage['metadata'] : undefined,
+      }));
+      onLoadSession(session.id, session.mode as 'batch' | 'interactive', messages);
+    } catch (err) {
+      console.error('Failed to load session:', err);
+    }
+  };
+
+  const grouped = groupByDate(sessions);
+  const groupOrder = ['Today', 'Yesterday', 'Previous 7 Days', 'Older'];
+
+  if (isLoading) {
+    return (
+      <div className="p-3 space-y-2">
+        <div className="h-4 w-24 bg-slate-800 rounded shimmer" />
+        <div className="h-10 bg-slate-800 rounded shimmer" />
+        <div className="h-10 bg-slate-800 rounded shimmer" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-3 space-y-3">
+      <div className="flex items-center justify-between">
+        <span className="text-xs font-medium text-slate-300">Chat Sessions</span>
+        <button
+          onClick={onNewChat}
+          className="flex items-center gap-1 px-2 py-1 text-[10px] font-medium rounded bg-primary/20 text-primary hover:bg-primary/30 transition-colors"
+          title="New chat"
+        >
+          <PlusIcon className="w-3 h-3" />
+          New Chat
+        </button>
+      </div>
+
+      <div className="space-y-3 max-h-[250px] overflow-y-auto scrollable">
+        {sessions.length === 0 ? (
+          <p className="text-xs text-slate-500 text-center py-4">
+            No conversations yet. Start typing to begin.
+          </p>
+        ) : (
+          groupOrder.map((group) => {
+            const items = grouped[group];
+            if (!items || items.length === 0) return null;
+            return (
+              <div key={group}>
+                <p className="text-[10px] font-mono text-slate-600 uppercase tracking-wider mb-1.5">
+                  {group}
+                </p>
+                <div className="space-y-1">
+                  {items.map((session) => (
+                    <div
+                      key={session.id}
+                      className={cn(
+                        'group relative w-full text-left p-2 rounded-md transition-colors cursor-pointer',
+                        'border border-transparent',
+                        activeSessionId === session.id
+                          ? 'bg-primary/10 border-primary/30'
+                          : 'hover:bg-slate-800/50'
+                      )}
+                      onClick={() => handleSelect(session)}
+                    >
+                      <div className="flex items-start justify-between gap-2">
+                        <div className="flex-1 min-w-0">
+                          <p className="text-xs text-slate-200 line-clamp-1">
+                            {session.title || 'New conversation...'}
+                          </p>
+                          <div className="flex items-center gap-1.5 mt-1">
+                            <ModeBadge mode={session.mode} />
+                            <span className="text-[10px] font-mono text-slate-500">
+                              {formatTimeAgo(session.updated_at || session.created_at)}
+                            </span>
+                          </div>
+                        </div>
+                        <div className="flex gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
+                          <button
+                            onClick={(e) => handleExport(e, session.id)}
+                            className="p-1 rounded hover:bg-slate-700 text-slate-500 hover:text-slate-300"
+                            title="Export"
+                          >
+                            <DownloadIcon className="w-3 h-3" />
+                          </button>
+                          <button
+                            onClick={(e) => handleDelete(e, session.id)}
+                            disabled={deletingId === session.id}
+                            className="p-1 rounded hover:bg-red-500/20 text-slate-500 hover:text-red-400"
+                            title="Delete"
+                          >
+                            <TrashIcon className="w-3 h-3" />
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            );
+          })
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/ui/icons.tsx
+++ b/frontend/src/components/ui/icons.tsx
@@ -293,6 +293,15 @@ export function UploadIcon({ className }: { className?: string }) {
   );
 }
 
+export function CopyIcon({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+      <path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1" />
+    </svg>
+  );
+}
+
 export function InfoIcon({ className }: { className?: string }) {
   return (
     <svg viewBox="0 0 16 16" fill="currentColor" className={className}>

--- a/frontend/src/hooks/useAppState.tsx
+++ b/frontend/src/hooks/useAppState.tsx
@@ -22,6 +22,7 @@ import type {
   ContactSavedResult,
   Contact,
   CustomCommand,
+  ChatSessionSummary,
 } from '@/types/api';
 import * as api from '@/lib/api';
 
@@ -172,6 +173,13 @@ interface AppState {
   settingsFlyoutOpen: boolean;
   setSettingsFlyoutOpen: (open: boolean) => void;
 
+  // Chat session history for sidebar
+  chatSessions: ChatSessionSummary[];
+  setChatSessions: (sessions: ChatSessionSummary[]) => void;
+  chatSessionsVersion: number;
+  refreshChatSessions: () => void;
+  activeSessionTitle: string | null;
+  setActiveSessionTitle: (title: string | null) => void;
 }
 
 const AppStateContext = React.createContext<AppState | null>(null);
@@ -225,6 +233,15 @@ export function AppStateProvider({ children }: { children: React.ReactNode }) {
 
   // Settings flyout state
   const [settingsFlyoutOpen, setSettingsFlyoutOpen] = React.useState(false);
+
+  // Chat session history state
+  const [chatSessions, setChatSessions] = React.useState<ChatSessionSummary[]>([]);
+  const [chatSessionsVersion, setChatSessionsVersion] = React.useState(0);
+  const [activeSessionTitle, setActiveSessionTitle] = React.useState<string | null>(null);
+
+  const refreshChatSessions = React.useCallback(() => {
+    setChatSessionsVersion((v) => v + 1);
+  }, []);
 
   // Refresh contacts from API
   const refreshContacts = React.useCallback(async () => {
@@ -310,6 +327,12 @@ export function AppStateProvider({ children }: { children: React.ReactNode }) {
     refreshCommands,
     settingsFlyoutOpen,
     setSettingsFlyoutOpen,
+    chatSessions,
+    setChatSessions,
+    chatSessionsVersion,
+    refreshChatSessions,
+    activeSessionTitle,
+    setActiveSessionTitle,
   };
 
   return (

--- a/frontend/src/hooks/useConversation.ts
+++ b/frontend/src/hooks/useConversation.ts
@@ -120,8 +120,8 @@ export function useConversation(): UseConversationReturn {
         };
 
         setEvents((prev) => [...prev, newEvent]);
-      } catch {
-        // Ignore unparseable messages
+      } catch (parseErr) {
+        console.warn('Unparseable SSE message:', parseErr);
       }
     };
 

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -1004,3 +1004,32 @@ export interface CommandListResponse {
   commands: CustomCommand[];
   total: number;
 }
+
+// === Chat Session Persistence ===
+
+/** Lightweight session summary for sidebar listing. */
+export interface ChatSessionSummary {
+  id: string;
+  title: string | null;
+  mode: 'batch' | 'interactive';
+  created_at: string;
+  updated_at: string | null;
+  message_count: number;
+}
+
+/** Persisted message for history display. */
+export interface PersistedMessage {
+  id: string;
+  role: 'user' | 'assistant' | 'system';
+  message_type: 'text' | 'system_artifact' | 'error' | 'tool_call';
+  content: string;
+  metadata: Record<string, unknown> | null;
+  sequence: number;
+  created_at: string;
+}
+
+/** Full session with messages for resume. */
+export interface SessionDetail {
+  session: ChatSessionSummary;
+  messages: PersistedMessage[];
+}

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -1013,7 +1013,7 @@ export interface ChatSessionSummary {
   title: string | null;
   mode: 'batch' | 'interactive';
   created_at: string;
-  updated_at: string | null;
+  updated_at: string;
   message_count: number;
 }
 
@@ -1021,7 +1021,7 @@ export interface ChatSessionSummary {
 export interface PersistedMessage {
   id: string;
   role: 'user' | 'assistant' | 'system';
-  message_type: 'text' | 'system_artifact' | 'error' | 'tool_call';
+  message_type: 'text' | 'system_artifact' | 'error';
   content: string;
   metadata: Record<string, unknown> | null;
   sequence: number;

--- a/src/api/routes/conversations.py
+++ b/src/api/routes/conversations.py
@@ -1025,10 +1025,16 @@ async def list_conversations(
         List of session summaries ordered by recency.
     """
     from src.db.connection import get_db_context
-    with get_db_context() as db:
-        svc = ConversationPersistenceService(db)
-        sessions = svc.list_sessions(active_only=active_only)
-    return [ChatSessionSummary(**s) for s in sessions[offset:offset + limit]]
+    try:
+        with get_db_context() as db:
+            svc = ConversationPersistenceService(db)
+            sessions = svc.list_sessions(
+                active_only=active_only, limit=limit, offset=offset,
+            )
+        return [ChatSessionSummary(**s) for s in sessions]
+    except Exception as exc:
+        logger.error("Failed to list conversations: %s", exc)
+        raise HTTPException(status_code=500, detail="Failed to list conversations")
 
 
 @router.get("/{session_id}/messages", response_model=SessionDetailResponse)

--- a/src/api/schemas_conversations.py
+++ b/src/api/schemas_conversations.py
@@ -102,7 +102,7 @@ class PersistedMessageResponse(BaseModel):
 
     id: str
     role: Literal["user", "assistant", "system"]
-    message_type: str
+    message_type: Literal["text", "system_artifact", "error"]
     content: str
     metadata: dict | None
     sequence: int

--- a/src/api/schemas_conversations.py
+++ b/src/api/schemas_conversations.py
@@ -4,6 +4,8 @@ Defines the request/response contracts for the agent-driven SSE
 conversation flow that replaces the legacy command endpoint.
 """
 
+from typing import Literal
+
 from pydantic import BaseModel, Field
 
 # UPS document type code → human-readable label mapping.
@@ -89,9 +91,9 @@ class ChatSessionSummary(BaseModel):
 
     id: str
     title: str | None
-    mode: str
+    mode: Literal["batch", "interactive"]
     created_at: str
-    updated_at: str | None
+    updated_at: str
     message_count: int
 
 
@@ -99,7 +101,7 @@ class PersistedMessageResponse(BaseModel):
     """Persisted message for history display."""
 
     id: str
-    role: str
+    role: Literal["user", "assistant", "system"]
     message_type: str
     content: str
     metadata: dict | None
@@ -117,4 +119,4 @@ class SessionDetailResponse(BaseModel):
 class UpdateTitleRequest(BaseModel):
     """Request to rename a session."""
 
-    title: str
+    title: str = Field(..., min_length=1, max_length=255)

--- a/src/api/schemas_conversations.py
+++ b/src/api/schemas_conversations.py
@@ -79,3 +79,42 @@ class UploadDocumentResponse(BaseModel):
     file_name: str
     file_format: str
     file_size_bytes: int
+
+
+# === Chat Session Persistence Schemas ===
+
+
+class ChatSessionSummary(BaseModel):
+    """Lightweight session summary for sidebar listing."""
+
+    id: str
+    title: str | None
+    mode: str
+    created_at: str
+    updated_at: str | None
+    message_count: int
+
+
+class PersistedMessageResponse(BaseModel):
+    """Persisted message for history display."""
+
+    id: str
+    role: str
+    message_type: str
+    content: str
+    metadata: dict | None
+    sequence: int
+    created_at: str
+
+
+class SessionDetailResponse(BaseModel):
+    """Full session with messages for resume."""
+
+    session: ChatSessionSummary
+    messages: list[PersistedMessageResponse]
+
+
+class UpdateTitleRequest(BaseModel):
+    """Request to rename a session."""
+
+    title: str

--- a/src/db/models.py
+++ b/src/db/models.py
@@ -688,3 +688,113 @@ class CustomCommand(Base):
 
     def __repr__(self) -> str:
         return f"<CustomCommand(name={self.name!r})>"
+
+
+class MessageType(str, Enum):
+    """Type classification for conversation messages.
+
+    Used by the visual timeline to determine dot color without
+    parsing metadata JSON.
+    """
+
+    text = "text"
+    system_artifact = "system_artifact"
+    error = "error"
+    tool_call = "tool_call"
+
+
+class ConversationSession(Base):
+    """Persistent conversation session.
+
+    Stores session metadata including mode, title, and context data
+    (active data source, source hash) for context-aware resume.
+
+    Attributes:
+        id: UUID primary key (same as runtime session_id).
+        title: Agent-generated title (nullable until first response).
+        mode: Shipping mode — 'batch' or 'interactive'.
+        context_data: JSON blob with data source reference and agent_source_hash.
+        is_active: Soft delete flag (False = archived).
+        created_at: ISO8601 creation timestamp.
+        updated_at: ISO8601 last-update timestamp.
+    """
+
+    __tablename__ = "conversation_sessions"
+    __table_args__ = (
+        Index("ix_convsess_active_updated", "is_active", "updated_at"),
+    )
+
+    id: Mapped[str] = mapped_column(
+        String(36), primary_key=True, default=generate_uuid
+    )
+    title: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    mode: Mapped[str] = mapped_column(
+        String(20), nullable=False, default="batch"
+    )
+    context_data: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    is_active: Mapped[bool] = mapped_column(nullable=False, default=True)
+    created_at: Mapped[str] = mapped_column(
+        String(50), nullable=False, default=utc_now_iso
+    )
+    updated_at: Mapped[Optional[str]] = mapped_column(String(50), nullable=True)
+
+    messages: Mapped[list["ConversationMessage"]] = relationship(
+        "ConversationMessage",
+        back_populates="session",
+        cascade="all, delete-orphan",
+        order_by="ConversationMessage.sequence",
+    )
+
+    def __repr__(self) -> str:
+        return f"<ConversationSession(id={self.id!r}, title={self.title!r})>"
+
+
+class ConversationMessage(Base):
+    """Persistent conversation message.
+
+    Stores rendered messages (user text, agent text, artifacts, errors)
+    for history display and agent context re-injection on resume.
+
+    Attributes:
+        id: UUID primary key.
+        session_id: FK to ConversationSession.
+        role: Message role — 'user', 'assistant', or 'system'.
+        message_type: Classification for timeline rendering.
+        content: Message text content.
+        metadata_json: Optional JSON with artifact data (action, preview, etc.).
+        sequence: Ordering within session (monotonically increasing).
+        created_at: ISO8601 creation timestamp.
+    """
+
+    __tablename__ = "conversation_messages"
+    __table_args__ = (
+        Index("ix_convmsg_session_seq", "session_id", "sequence"),
+        Index("ix_convmsg_session_type", "session_id", "message_type"),
+    )
+
+    id: Mapped[str] = mapped_column(
+        String(36), primary_key=True, default=generate_uuid
+    )
+    session_id: Mapped[str] = mapped_column(
+        String(36), ForeignKey("conversation_sessions.id"), nullable=False
+    )
+    role: Mapped[str] = mapped_column(String(20), nullable=False)
+    message_type: Mapped[str] = mapped_column(
+        String(30), nullable=False, default=MessageType.text.value
+    )
+    content: Mapped[str] = mapped_column(Text, nullable=False)
+    metadata_json: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    sequence: Mapped[int] = mapped_column(Integer, nullable=False)
+    created_at: Mapped[str] = mapped_column(
+        String(50), nullable=False, default=utc_now_iso
+    )
+
+    session: Mapped["ConversationSession"] = relationship(
+        "ConversationSession", back_populates="messages"
+    )
+
+    def __repr__(self) -> str:
+        return (
+            f"<ConversationMessage(id={self.id!r}, role={self.role!r}, "
+            f"seq={self.sequence})>"
+        )

--- a/src/orchestrator/agent/system_prompt.py
+++ b/src/orchestrator/agent/system_prompt.py
@@ -254,11 +254,86 @@ and all US state names (e.g., "california" → "CA").
 """
 
 
+MAX_RESUME_MESSAGES = 30
+MAX_RESUME_TOKENS = 4000  # ~16K chars at ~4 chars/token
+
+
+def _estimate_token_count(text: str) -> int:
+    """Rough token estimate at ~4 characters per token.
+
+    Args:
+        text: Input text.
+
+    Returns:
+        Estimated token count.
+    """
+    return len(text) // 4
+
+
+def _build_prior_conversation_section(
+    messages: list[dict],
+) -> str:
+    """Build a prior conversation section for session resume.
+
+    Applies two limits to control prompt size:
+    1. MAX_RESUME_MESSAGES — hard cap on message count.
+    2. MAX_RESUME_TOKENS — estimated token budget. Messages are
+       included newest-first until the budget is exhausted.
+
+    Args:
+        messages: List of {role, content} dicts from persisted history.
+
+    Returns:
+        Formatted conversation history section, or empty string.
+    """
+    if not messages:
+        return ""
+
+    # Start from the most recent messages and work backwards
+    candidates = messages[-MAX_RESUME_MESSAGES:]
+    included: list[dict] = []
+    token_budget = MAX_RESUME_TOKENS
+
+    for msg in reversed(candidates):
+        content = msg.get("content", "")
+        # Truncate very long individual messages
+        if len(content) > 500:
+            content = content[:497] + "..."
+        cost = _estimate_token_count(content) + 10  # overhead for role label
+        if token_budget - cost < 0 and included:
+            break  # budget exhausted
+        token_budget -= cost
+        included.append({"role": msg.get("role", "unknown"), "content": content})
+
+    included.reverse()  # Restore chronological order
+
+    if not included:
+        return ""
+
+    lines = [
+        "## Prior Conversation (Resumed Session)",
+        "",
+        "You are resuming a prior conversation. Here is the recent history:",
+        "",
+    ]
+
+    omitted = len(messages) - len(included)
+    if omitted > 0:
+        lines.append(f"({omitted} earlier messages omitted)")
+        lines.append("")
+
+    for msg in included:
+        lines.append(f"[{msg['role']}]: {msg['content']}")
+
+    return "\n".join(lines)
+
+
 def build_system_prompt(
     source_info: DataSourceInfo | None = None,
     interactive_shipping: bool = False,
     column_samples: dict[str, list] | None = None,
     contacts: list[dict] | None = None,
+    prior_conversation: list[dict] | None = None,
 ) -> str:
     """Build the complete system prompt for the orchestration agent.
 
@@ -275,6 +350,7 @@ def build_system_prompt(
         interactive_shipping: Whether interactive single-shipment mode is enabled.
         column_samples: Optional sample values per column for filter grounding.
         contacts: Optional list of saved contacts for @handle resolution.
+        prior_conversation: Optional list of {role, content} dicts for session resume.
 
     Returns:
         Complete system prompt string.
@@ -577,6 +653,11 @@ administrator.
     # Build contacts section if contacts are provided
     contacts_section = _build_contacts_section(contacts) if contacts else ""
 
+    # Prior conversation section for session resume
+    prior_section = ""
+    if prior_conversation:
+        prior_section = _build_prior_conversation_section(prior_conversation)
+
     return f"""You are ShipAgent, an AI shipping assistant that helps users create, rate, and manage UPS shipments from their data sources.
 
 Current date: {current_date}
@@ -590,6 +671,7 @@ Current date: {current_date}
 
 {data_section}
 {contacts_section}
+{prior_section}
 ## Filter Generation Rules
 
 {filter_rules_section}

--- a/src/services/conversation_handler.py
+++ b/src/services/conversation_handler.py
@@ -61,6 +61,36 @@ def _get_mru_contacts_for_prompt() -> list[dict]:
         return []
 
 
+def _load_prior_conversation(session_id: str) -> list[dict] | None:
+    """Load prior conversation messages from DB for system prompt injection.
+
+    Mirrors the _get_mru_contacts_for_prompt() pattern: uses get_db_context
+    for clean session management, returns data or None on failure.
+
+    Args:
+        session_id: The conversation session ID.
+
+    Returns:
+        List of {role, content} dicts, or None if no history exists.
+    """
+    from src.db.connection import get_db_context
+    from src.services.conversation_persistence_service import ConversationPersistenceService
+
+    try:
+        with get_db_context() as db:
+            svc = ConversationPersistenceService(db)
+            result = svc.get_session_with_messages(session_id, limit=30)
+            if result is None or not result["messages"]:
+                return None
+            return [
+                {"role": m["role"], "content": m["content"]}
+                for m in result["messages"]
+            ]
+    except Exception as e:
+        logger.warning("Failed to load prior conversation for %s: %s", session_id, e)
+        return None
+
+
 def compute_source_hash(source_info: Any) -> str:
     """Compute hash of current data source for change detection.
 
@@ -116,10 +146,14 @@ async def ensure_agent(
         except Exception as e:
             logger.warning("Error stopping old agent: %s", e)
 
+    # Load prior conversation for resumed sessions
+    prior_conversation = _load_prior_conversation(session.session_id)
+
     system_prompt = build_system_prompt(
         source_info=source_info,
         interactive_shipping=interactive_shipping,
         contacts=contacts,
+        prior_conversation=prior_conversation,
     )
 
     agent = OrchestrationAgent(

--- a/src/services/conversation_handler.py
+++ b/src/services/conversation_handler.py
@@ -23,6 +23,9 @@ from src.services.gateway_provider import get_data_gateway
 
 logger = logging.getLogger(__name__)
 
+# Max messages to load for system prompt injection on resume
+MAX_RESUME_MESSAGES = 30
+
 
 def _get_mru_contacts_for_prompt() -> list[dict]:
     """Fetch MRU contacts for system prompt injection.
@@ -79,7 +82,7 @@ def _load_prior_conversation(session_id: str) -> list[dict] | None:
     try:
         with get_db_context() as db:
             svc = ConversationPersistenceService(db)
-            result = svc.get_session_with_messages(session_id, limit=30)
+            result = svc.get_session_with_messages(session_id, limit=MAX_RESUME_MESSAGES)
             if result is None or not result["messages"]:
                 return None
             return [

--- a/src/services/conversation_persistence_service.py
+++ b/src/services/conversation_persistence_service.py
@@ -1,0 +1,267 @@
+"""Persistence service for conversation sessions and messages.
+
+Thin layer between API routes and SQLAlchemy models. All conversation
+history reads and writes go through this service. The frontend never
+writes messages — the backend owns all persistence.
+"""
+
+import json
+from typing import Any, Optional
+
+from sqlalchemy.orm import Session
+
+from src.db.models import (
+    ConversationMessage,
+    ConversationSession,
+    MessageType,
+    generate_uuid,
+    utc_now_iso,
+)
+
+
+class ConversationPersistenceService:
+    """CRUD operations for persistent conversation sessions and messages.
+
+    Args:
+        db: SQLAlchemy session (sync).
+    """
+
+    def __init__(self, db: Session) -> None:
+        self._db = db
+
+    def create_session(
+        self,
+        session_id: str,
+        mode: str = "batch",
+        context_data: dict[str, Any] | None = None,
+    ) -> ConversationSession:
+        """Create a new conversation session row.
+
+        Args:
+            session_id: UUID for the session (matches runtime session_id).
+            mode: 'batch' or 'interactive'.
+            context_data: Optional JSON-serializable context snapshot.
+
+        Returns:
+            The created ConversationSession.
+        """
+        session = ConversationSession(
+            id=session_id,
+            mode=mode,
+            context_data=json.dumps(context_data) if context_data else None,
+        )
+        self._db.add(session)
+        self._db.commit()
+        return session
+
+    def save_message(
+        self,
+        session_id: str,
+        role: str,
+        content: str,
+        message_type: str = MessageType.text.value,
+        metadata: dict[str, Any] | None = None,
+    ) -> ConversationMessage:
+        """Append a message to a session with auto-incrementing sequence.
+
+        Args:
+            session_id: Parent session ID.
+            role: 'user', 'assistant', or 'system'.
+            content: Message text.
+            message_type: Classification for timeline (default 'text').
+            metadata: Optional artifact metadata dict.
+
+        Returns:
+            The created ConversationMessage.
+        """
+        # Compute next sequence number.
+        # Note: For SQLite with single-writer semantics, SELECT+INSERT
+        # is safe within a single transaction. If migrating to Postgres with
+        # concurrent writes, consider using a DB sequence or SELECT FOR UPDATE.
+        max_seq = (
+            self._db.query(ConversationMessage.sequence)
+            .filter_by(session_id=session_id)
+            .order_by(ConversationMessage.sequence.desc())
+            .first()
+        )
+        next_seq = (max_seq[0] + 1) if max_seq else 1
+
+        msg = ConversationMessage(
+            id=generate_uuid(),
+            session_id=session_id,
+            role=role,
+            message_type=message_type,
+            content=content,
+            metadata_json=json.dumps(metadata) if metadata else None,
+            sequence=next_seq,
+        )
+        self._db.add(msg)
+
+        # Update session's updated_at
+        session = self._db.get(ConversationSession, session_id)
+        if session:
+            session.updated_at = utc_now_iso()
+
+        self._db.commit()
+        return msg
+
+    def list_sessions(
+        self, active_only: bool = True
+    ) -> list[dict[str, Any]]:
+        """List conversation sessions with message counts.
+
+        Uses explicit column selection to avoid loading heavy columns
+        (context_data) that the sidebar listing doesn't need.
+
+        Args:
+            active_only: If True, exclude soft-deleted sessions.
+
+        Returns:
+            List of session summary dicts (lightweight — no context_data).
+        """
+        from sqlalchemy import func
+
+        query = self._db.query(
+            ConversationSession.id,
+            ConversationSession.title,
+            ConversationSession.mode,
+            ConversationSession.created_at,
+            ConversationSession.updated_at,
+            func.count(ConversationMessage.id).label("message_count"),
+        ).outerjoin(ConversationMessage).group_by(ConversationSession.id)
+
+        if active_only:
+            query = query.filter(ConversationSession.is_active == True)  # noqa: E712
+
+        query = query.order_by(
+            ConversationSession.updated_at.desc().nullslast(),
+            ConversationSession.created_at.desc(),
+        )
+
+        results = []
+        for row in query.all():
+            results.append({
+                "id": row[0],
+                "title": row[1],
+                "mode": row[2],
+                "created_at": row[3],
+                "updated_at": row[4],
+                "message_count": row[5],
+            })
+        return results
+
+    def get_session_with_messages(
+        self,
+        session_id: str,
+        limit: int | None = None,
+        offset: int = 0,
+    ) -> dict[str, Any] | None:
+        """Load a session with its messages for resume/display.
+
+        Args:
+            session_id: Session ID.
+            limit: Max messages to return (None = all).
+            offset: Skip first N messages.
+
+        Returns:
+            Dict with 'session' and 'messages' keys, or None if not found.
+        """
+        session = self._db.get(ConversationSession, session_id)
+        if session is None:
+            return None
+
+        query = (
+            self._db.query(ConversationMessage)
+            .filter_by(session_id=session_id)
+            .order_by(ConversationMessage.sequence)
+            .offset(offset)
+        )
+        if limit is not None:
+            query = query.limit(limit)
+
+        messages = [
+            {
+                "id": m.id,
+                "role": m.role,
+                "message_type": m.message_type,
+                "content": m.content,
+                "metadata": json.loads(m.metadata_json) if m.metadata_json else None,
+                "sequence": m.sequence,
+                "created_at": m.created_at,
+            }
+            for m in query.all()
+        ]
+
+        return {
+            "session": {
+                "id": session.id,
+                "title": session.title,
+                "mode": session.mode,
+                "context_data": json.loads(session.context_data) if session.context_data else None,
+                "is_active": session.is_active,
+                "created_at": session.created_at,
+                "updated_at": session.updated_at,
+            },
+            "messages": messages,
+        }
+
+    def update_session_title(self, session_id: str, title: str) -> None:
+        """Set the session title.
+
+        Args:
+            session_id: Session ID.
+            title: New title string.
+        """
+        session = self._db.get(ConversationSession, session_id)
+        if session:
+            session.title = title
+            session.updated_at = utc_now_iso()
+            self._db.commit()
+
+    def update_session_context(
+        self, session_id: str, context_data: dict[str, Any]
+    ) -> None:
+        """Update the session's context snapshot.
+
+        Args:
+            session_id: Session ID.
+            context_data: New context dict.
+        """
+        session = self._db.get(ConversationSession, session_id)
+        if session:
+            session.context_data = json.dumps(context_data)
+            session.updated_at = utc_now_iso()
+            self._db.commit()
+
+    def soft_delete_session(self, session_id: str) -> None:
+        """Soft-delete a session (set is_active = False).
+
+        Args:
+            session_id: Session ID.
+        """
+        session = self._db.get(ConversationSession, session_id)
+        if session:
+            session.is_active = False
+            session.updated_at = utc_now_iso()
+            self._db.commit()
+
+    def export_session_json(
+        self, session_id: str
+    ) -> dict[str, Any] | None:
+        """Export a full session with all messages as JSON.
+
+        Args:
+            session_id: Session ID.
+
+        Returns:
+            Complete session dict suitable for JSON download, or None.
+        """
+        result = self.get_session_with_messages(session_id)
+        if result is None:
+            return None
+
+        return {
+            "exported_at": utc_now_iso(),
+            "session": result["session"],
+            "messages": result["messages"],
+        }

--- a/tests/api/test_conversation_persistence_endpoints.py
+++ b/tests/api/test_conversation_persistence_endpoints.py
@@ -1,0 +1,210 @@
+"""HTTP-level tests for conversation persistence endpoints.
+
+Tests the 5 new persistence routes via TestClient, verifying
+serialization, status codes, query params, and 404 handling.
+"""
+
+from contextlib import contextmanager
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from src.db.models import Base
+from src.services.conversation_persistence_service import ConversationPersistenceService
+
+
+@pytest.fixture
+def persistence_db():
+    """In-memory SQLite for persistence tests."""
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(bind=engine)
+    factory = sessionmaker(bind=engine)
+    session = factory()
+    yield session
+    session.close()
+
+
+@pytest.fixture
+def patched_client(persistence_db: Session):
+    """TestClient with get_db_context patched to use test DB."""
+    from src.api.main import app
+
+    @contextmanager
+    def _test_db_context():
+        yield persistence_db
+
+    with patch("src.db.connection.get_db_context", _test_db_context):
+        with TestClient(app) as c:
+            yield c
+
+
+@pytest.fixture
+def seeded_session(persistence_db: Session) -> str:
+    """Create a session with messages in the test DB."""
+    svc = ConversationPersistenceService(persistence_db)
+    svc.create_session(session_id="sess-1", mode="batch")
+    svc.save_message("sess-1", "user", "Ship all CA orders via Ground")
+    svc.save_message("sess-1", "assistant", "I'll process those orders now.")
+    svc.update_session_title("sess-1", "CA Ground Batch")
+    return "sess-1"
+
+
+class TestListConversations:
+    """GET /api/v1/conversations/"""
+
+    def test_returns_empty_list(self, patched_client: TestClient):
+        """Returns empty list when no sessions exist."""
+        resp = patched_client.get("/api/v1/conversations/")
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+    def test_returns_sessions(
+        self, patched_client: TestClient, seeded_session: str
+    ):
+        """Returns session summaries with correct fields."""
+        resp = patched_client.get("/api/v1/conversations/")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 1
+        session = data[0]
+        assert session["id"] == "sess-1"
+        assert session["title"] == "CA Ground Batch"
+        assert session["mode"] == "batch"
+        assert session["message_count"] == 2
+        assert "created_at" in session
+        assert "updated_at" in session
+
+    def test_pagination(
+        self,
+        patched_client: TestClient,
+        persistence_db: Session,
+    ):
+        """Respects limit and offset query params."""
+        svc = ConversationPersistenceService(persistence_db)
+        for i in range(5):
+            svc.create_session(session_id=f"s-{i}", mode="batch")
+        resp = patched_client.get(
+            "/api/v1/conversations/", params={"limit": 2, "offset": 1}
+        )
+        assert resp.status_code == 200
+        assert len(resp.json()) == 2
+
+
+class TestGetSessionMessages:
+    """GET /api/v1/conversations/{id}/messages"""
+
+    def test_returns_messages(
+        self, patched_client: TestClient, seeded_session: str
+    ):
+        """Returns session detail with ordered messages."""
+        resp = patched_client.get("/api/v1/conversations/sess-1/messages")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["session"]["id"] == "sess-1"
+        assert len(data["messages"]) == 2
+        assert data["messages"][0]["role"] == "user"
+        assert data["messages"][1]["role"] == "assistant"
+        assert data["messages"][0]["sequence"] == 1
+
+    def test_404_for_missing(self, patched_client: TestClient):
+        """Returns 404 for non-existent session."""
+        resp = patched_client.get("/api/v1/conversations/nonexistent/messages")
+        assert resp.status_code == 404
+
+    def test_pagination_params(
+        self, patched_client: TestClient, seeded_session: str
+    ):
+        """Respects limit and offset query params."""
+        resp = patched_client.get(
+            "/api/v1/conversations/sess-1/messages",
+            params={"limit": 1, "offset": 1},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["messages"]) == 1
+        assert data["messages"][0]["role"] == "assistant"
+
+
+class TestUpdateTitle:
+    """PATCH /api/v1/conversations/{id}"""
+
+    def test_updates_title(
+        self, patched_client: TestClient, seeded_session: str
+    ):
+        """Updates session title and returns new value."""
+        resp = patched_client.patch(
+            "/api/v1/conversations/sess-1",
+            json={"title": "New Title"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["title"] == "New Title"
+
+    def test_404_for_missing(self, patched_client: TestClient):
+        """Returns 404 for non-existent session."""
+        resp = patched_client.patch(
+            "/api/v1/conversations/nonexistent",
+            json={"title": "No Session"},
+        )
+        assert resp.status_code == 404
+
+    def test_rejects_empty_title(
+        self, patched_client: TestClient, seeded_session: str
+    ):
+        """Rejects empty string title (422 validation)."""
+        resp = patched_client.patch(
+            "/api/v1/conversations/sess-1",
+            json={"title": ""},
+        )
+        assert resp.status_code == 422
+
+
+class TestExportConversation:
+    """GET /api/v1/conversations/{id}/export"""
+
+    def test_exports_json(
+        self, patched_client: TestClient, seeded_session: str
+    ):
+        """Returns downloadable JSON with session and messages."""
+        resp = patched_client.get("/api/v1/conversations/sess-1/export")
+        assert resp.status_code == 200
+        assert "application/json" in resp.headers["content-type"]
+        assert "attachment" in resp.headers.get("content-disposition", "")
+        data = resp.json()
+        assert data["session"]["id"] == "sess-1"
+        assert len(data["messages"]) == 2
+        assert "exported_at" in data
+
+    def test_404_for_missing(self, patched_client: TestClient):
+        """Returns 404 for non-existent session."""
+        resp = patched_client.get("/api/v1/conversations/nonexistent/export")
+        assert resp.status_code == 404
+
+
+class TestDeleteConversation:
+    """DELETE /api/v1/conversations/{id}"""
+
+    def test_soft_deletes(
+        self,
+        patched_client: TestClient,
+        seeded_session: str,
+    ):
+        """Soft-deletes session, removing it from active listing."""
+        # Session appears in list
+        resp = patched_client.get("/api/v1/conversations/")
+        assert len(resp.json()) == 1
+
+        # Delete
+        resp = patched_client.delete("/api/v1/conversations/sess-1")
+        assert resp.status_code == 204
+
+        # No longer in active list
+        resp = patched_client.get("/api/v1/conversations/")
+        assert len(resp.json()) == 0

--- a/tests/api/test_conversation_schemas.py
+++ b/tests/api/test_conversation_schemas.py
@@ -1,0 +1,51 @@
+"""Tests for conversation persistence Pydantic schemas."""
+
+from src.api.schemas_conversations import (
+    ChatSessionSummary,
+    SessionDetailResponse,
+    PersistedMessageResponse,
+    UpdateTitleRequest,
+)
+
+
+def test_chat_session_summary_fields():
+    s = ChatSessionSummary(
+        id="abc",
+        title="Test",
+        mode="batch",
+        created_at="2026-02-20T00:00:00Z",
+        updated_at=None,
+        message_count=5,
+    )
+    assert s.id == "abc"
+    assert s.message_count == 5
+
+
+def test_persisted_message_response():
+    m = PersistedMessageResponse(
+        id="msg-1",
+        role="user",
+        message_type="text",
+        content="hello",
+        metadata=None,
+        sequence=1,
+        created_at="2026-02-20T00:00:00Z",
+    )
+    assert m.sequence == 1
+
+
+def test_session_detail_response():
+    r = SessionDetailResponse(
+        session=ChatSessionSummary(
+            id="s1", title=None, mode="interactive",
+            created_at="2026-02-20T00:00:00Z",
+            updated_at=None, message_count=0,
+        ),
+        messages=[],
+    )
+    assert r.session.mode == "interactive"
+
+
+def test_update_title_request():
+    req = UpdateTitleRequest(title="New Title")
+    assert req.title == "New Title"

--- a/tests/api/test_conversation_schemas.py
+++ b/tests/api/test_conversation_schemas.py
@@ -14,7 +14,7 @@ def test_chat_session_summary_fields():
         title="Test",
         mode="batch",
         created_at="2026-02-20T00:00:00Z",
-        updated_at=None,
+        updated_at="2026-02-20T00:00:00Z",
         message_count=5,
     )
     assert s.id == "abc"
@@ -39,7 +39,7 @@ def test_session_detail_response():
         session=ChatSessionSummary(
             id="s1", title=None, mode="interactive",
             created_at="2026-02-20T00:00:00Z",
-            updated_at=None, message_count=0,
+            updated_at="2026-02-20T00:00:00Z", message_count=0,
         ),
         messages=[],
     )
@@ -49,3 +49,9 @@ def test_session_detail_response():
 def test_update_title_request():
     req = UpdateTitleRequest(title="New Title")
     assert req.title == "New Title"
+
+
+def test_update_title_rejects_empty():
+    import pytest as _pytest
+    with _pytest.raises(Exception):
+        UpdateTitleRequest(title="")

--- a/tests/api/test_conversations_persistence.py
+++ b/tests/api/test_conversations_persistence.py
@@ -1,0 +1,103 @@
+"""Integration tests for conversation persistence API endpoints.
+
+Tests the persistence service layer directly (not HTTP routes) to verify
+the conversation CRUD operations that the new API endpoints depend on.
+"""
+
+import json
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from src.db.models import Base, ConversationSession
+
+
+@pytest.fixture
+def db_session():
+    """In-memory SQLite for testing."""
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    SessionLocal = sessionmaker(bind=engine)
+    session = SessionLocal()
+    yield session
+    session.close()
+
+
+@pytest.fixture
+def persistence_svc(db_session):
+    """ConversationPersistenceService for seeding test data."""
+    from src.services.conversation_persistence_service import (
+        ConversationPersistenceService,
+    )
+    return ConversationPersistenceService(db_session)
+
+
+class TestListConversations:
+    """GET /conversations endpoint."""
+
+    def test_list_returns_sessions(self, persistence_svc, db_session):
+        persistence_svc.create_session(session_id="s1", mode="batch")
+        persistence_svc.create_session(session_id="s2", mode="interactive")
+        sessions = persistence_svc.list_sessions()
+        assert len(sessions) == 2
+
+    def test_list_excludes_deleted(self, persistence_svc, db_session):
+        persistence_svc.create_session(session_id="s1", mode="batch")
+        persistence_svc.soft_delete_session("s1")
+        sessions = persistence_svc.list_sessions(active_only=True)
+        assert len(sessions) == 0
+
+
+class TestGetMessages:
+    """GET /conversations/{id}/messages endpoint."""
+
+    def test_returns_ordered_messages(self, persistence_svc, db_session):
+        persistence_svc.create_session(session_id="s1", mode="batch")
+        persistence_svc.save_message("s1", "user", "first")
+        persistence_svc.save_message("s1", "assistant", "second")
+        result = persistence_svc.get_session_with_messages("s1")
+        assert len(result["messages"]) == 2
+        assert result["messages"][0]["role"] == "user"
+
+    def test_pagination(self, persistence_svc, db_session):
+        persistence_svc.create_session(session_id="s1", mode="batch")
+        for i in range(10):
+            persistence_svc.save_message("s1", "user", f"msg {i}")
+        result = persistence_svc.get_session_with_messages("s1", limit=5)
+        assert len(result["messages"]) == 5
+
+
+class TestSoftDelete:
+    """DELETE /conversations/{id} soft delete."""
+
+    def test_soft_deletes(self, persistence_svc, db_session):
+        persistence_svc.create_session(session_id="s1", mode="batch")
+        persistence_svc.soft_delete_session("s1")
+        sess = db_session.get(ConversationSession, "s1")
+        assert sess.is_active is False
+
+
+class TestExport:
+    """GET /conversations/{id}/export."""
+
+    def test_exports_json(self, persistence_svc, db_session):
+        persistence_svc.create_session(session_id="s1", mode="batch")
+        persistence_svc.save_message("s1", "user", "hello")
+        export = persistence_svc.export_session_json("s1")
+        assert export["session"]["id"] == "s1"
+        assert len(export["messages"]) == 1
+        assert "exported_at" in export
+
+    def test_export_missing_returns_none(self, persistence_svc):
+        assert persistence_svc.export_session_json("nope") is None
+
+
+class TestUpdateTitle:
+    """PATCH /conversations/{id}."""
+
+    def test_updates_title(self, persistence_svc, db_session):
+        persistence_svc.create_session(session_id="s1", mode="batch")
+        persistence_svc.update_session_title("s1", "Ground Batch")
+        sess = db_session.get(ConversationSession, "s1")
+        assert sess.title == "Ground Batch"

--- a/tests/db/test_conversation_models.py
+++ b/tests/db/test_conversation_models.py
@@ -1,0 +1,189 @@
+"""Tests for ConversationSession and ConversationMessage models."""
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+
+from src.db.models import (
+    Base,
+    ConversationMessage,
+    ConversationSession,
+    MessageType,
+    generate_uuid,
+    utc_now_iso,
+)
+
+
+@pytest.fixture
+def db_session():
+    """Create an in-memory SQLite session for testing."""
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    SessionLocal = sessionmaker(bind=engine)
+    session = SessionLocal()
+    yield session
+    session.close()
+
+
+class TestMessageTypeEnum:
+    """MessageType enum values and str inheritance."""
+
+    def test_text_value(self):
+        assert MessageType.text.value == "text"
+
+    def test_system_artifact_value(self):
+        assert MessageType.system_artifact.value == "system_artifact"
+
+    def test_error_value(self):
+        assert MessageType.error.value == "error"
+
+    def test_tool_call_value(self):
+        assert MessageType.tool_call.value == "tool_call"
+
+    def test_is_string(self):
+        assert isinstance(MessageType.text, str)
+
+
+class TestConversationSession:
+    """ConversationSession model CRUD."""
+
+    def test_create_session_defaults(self, db_session: Session):
+        session = ConversationSession(id=generate_uuid())
+        db_session.add(session)
+        db_session.commit()
+
+        assert session.mode == "batch"
+        assert session.is_active is True
+        assert session.title is None
+        assert session.context_data is None
+        assert session.created_at is not None
+
+    def test_create_session_interactive(self, db_session: Session):
+        session = ConversationSession(
+            id=generate_uuid(),
+            mode="interactive",
+            title="Test Session",
+        )
+        db_session.add(session)
+        db_session.commit()
+
+        assert session.mode == "interactive"
+        assert session.title == "Test Session"
+
+    def test_soft_delete(self, db_session: Session):
+        session = ConversationSession(id=generate_uuid())
+        db_session.add(session)
+        db_session.commit()
+
+        session.is_active = False
+        db_session.commit()
+
+        result = db_session.query(ConversationSession).filter_by(
+            is_active=True
+        ).all()
+        assert len(result) == 0
+
+    def test_context_data_json(self, db_session: Session):
+        import json
+        ctx = json.dumps({"data_source_id": "abc", "agent_source_hash": "xyz"})
+        session = ConversationSession(id=generate_uuid(), context_data=ctx)
+        db_session.add(session)
+        db_session.commit()
+
+        loaded = json.loads(session.context_data)
+        assert loaded["data_source_id"] == "abc"
+        assert loaded["agent_source_hash"] == "xyz"
+
+
+class TestConversationMessage:
+    """ConversationMessage model CRUD and relationships."""
+
+    def _make_session(self, db_session: Session) -> ConversationSession:
+        s = ConversationSession(id=generate_uuid())
+        db_session.add(s)
+        db_session.commit()
+        return s
+
+    def test_create_message(self, db_session: Session):
+        s = self._make_session(db_session)
+        msg = ConversationMessage(
+            id=generate_uuid(),
+            session_id=s.id,
+            role="user",
+            content="Ship all CA orders",
+            sequence=1,
+        )
+        db_session.add(msg)
+        db_session.commit()
+
+        assert msg.message_type == MessageType.text.value
+        assert msg.role == "user"
+        assert msg.sequence == 1
+
+    def test_message_types(self, db_session: Session):
+        s = self._make_session(db_session)
+        for i, mt in enumerate(MessageType):
+            msg = ConversationMessage(
+                id=generate_uuid(),
+                session_id=s.id,
+                role="system",
+                message_type=mt.value,
+                content=f"test {mt.value}",
+                sequence=i,
+            )
+            db_session.add(msg)
+        db_session.commit()
+
+        msgs = db_session.query(ConversationMessage).filter_by(
+            session_id=s.id
+        ).order_by(ConversationMessage.sequence).all()
+        assert len(msgs) == len(MessageType)
+
+    def test_relationship_cascade_delete(self, db_session: Session):
+        s = self._make_session(db_session)
+        for i in range(3):
+            db_session.add(ConversationMessage(
+                id=generate_uuid(),
+                session_id=s.id,
+                role="user",
+                content=f"msg {i}",
+                sequence=i,
+            ))
+        db_session.commit()
+
+        db_session.delete(s)
+        db_session.commit()
+
+        remaining = db_session.query(ConversationMessage).all()
+        assert len(remaining) == 0
+
+    def test_ordering_by_sequence(self, db_session: Session):
+        s = self._make_session(db_session)
+        for seq in [3, 1, 2]:
+            db_session.add(ConversationMessage(
+                id=generate_uuid(),
+                session_id=s.id,
+                role="user",
+                content=f"seq {seq}",
+                sequence=seq,
+            ))
+        db_session.commit()
+
+        msgs = db_session.query(ConversationMessage).filter_by(
+            session_id=s.id
+        ).order_by(ConversationMessage.sequence).all()
+        assert [m.sequence for m in msgs] == [1, 2, 3]
+
+    def test_metadata_json_nullable(self, db_session: Session):
+        s = self._make_session(db_session)
+        msg = ConversationMessage(
+            id=generate_uuid(),
+            session_id=s.id,
+            role="assistant",
+            content="Done",
+            sequence=1,
+            metadata_json=None,
+        )
+        db_session.add(msg)
+        db_session.commit()
+        assert msg.metadata_json is None

--- a/tests/db/test_conversation_models.py
+++ b/tests/db/test_conversation_models.py
@@ -37,9 +37,6 @@ class TestMessageTypeEnum:
     def test_error_value(self):
         assert MessageType.error.value == "error"
 
-    def test_tool_call_value(self):
-        assert MessageType.tool_call.value == "tool_call"
-
     def test_is_string(self):
         assert isinstance(MessageType.text, str)
 

--- a/tests/orchestrator/agent/test_system_prompt_resume.py
+++ b/tests/orchestrator/agent/test_system_prompt_resume.py
@@ -1,0 +1,48 @@
+"""Tests for prior conversation injection in system prompt."""
+
+from src.orchestrator.agent.system_prompt import build_system_prompt
+
+
+def test_no_prior_conversation_by_default():
+    prompt = build_system_prompt()
+    assert "Prior Conversation" not in prompt
+
+
+def test_prior_conversation_injected():
+    history = [
+        {"role": "user", "content": "Ship CA orders via Ground"},
+        {"role": "assistant", "content": "I'll help with that."},
+    ]
+    prompt = build_system_prompt(prior_conversation=history)
+    assert "Prior Conversation" in prompt
+    assert "Ship CA orders via Ground" in prompt
+    assert "I'll help with that." in prompt
+
+
+def test_prior_conversation_truncation():
+    history = [
+        {"role": "user", "content": f"Message {i}"}
+        for i in range(50)
+    ]
+    prompt = build_system_prompt(prior_conversation=history)
+    # Should truncate to most recent messages (capped by count + token budget)
+    assert "Message 49" in prompt
+    assert "Message 0" not in prompt
+    assert "earlier messages omitted" in prompt
+
+
+def test_prior_conversation_token_budget():
+    """Long messages should be limited by token budget, not just count."""
+    history = [
+        {"role": "user", "content": "x" * 2000}  # ~500 tokens each
+        for _ in range(30)
+    ]
+    prompt = build_system_prompt(prior_conversation=history)
+    assert "Prior Conversation" in prompt
+    # Token budget (~4000 tokens) should cap inclusion before all 30 fit
+    assert "earlier messages omitted" in prompt
+
+
+def test_prior_conversation_empty_list():
+    prompt = build_system_prompt(prior_conversation=[])
+    assert "Prior Conversation" not in prompt

--- a/tests/services/test_conversation_handler_resume.py
+++ b/tests/services/test_conversation_handler_resume.py
@@ -1,0 +1,151 @@
+"""Tests for _load_prior_conversation and ensure_agent resume wiring."""
+
+from contextlib import contextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from src.db.models import Base
+from src.services.conversation_persistence_service import ConversationPersistenceService
+
+# Pre-load submodules so patch() can resolve dotted paths for lazy imports
+import src.orchestrator.agent.client  # noqa: F401
+import src.orchestrator.agent.system_prompt  # noqa: F401
+
+
+@pytest.fixture
+def db_session():
+    """In-memory SQLite for testing."""
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    SessionLocal = sessionmaker(bind=engine)
+    session = SessionLocal()
+    yield session
+    session.close()
+
+
+def _seed_session_with_messages(db_session, session_id: str, count: int = 5):
+    """Seed a session with messages for testing."""
+    svc = ConversationPersistenceService(db_session)
+    svc.create_session(session_id=session_id, mode="batch")
+    for i in range(count):
+        role = "user" if i % 2 == 0 else "assistant"
+        svc.save_message(session_id, role, f"Message {i}")
+
+
+def _mock_db_context(db_session):
+    """Create a context manager mock for get_db_context."""
+    @contextmanager
+    def fake_ctx():
+        yield db_session
+    return fake_ctx
+
+
+class TestLoadPriorConversation:
+    """Unit tests for _load_prior_conversation helper."""
+
+    def test_returns_none_for_missing_session(self, db_session):
+        """Non-existent session returns None."""
+        with patch("src.db.connection.get_db_context", _mock_db_context(db_session)):
+            from src.services.conversation_handler import _load_prior_conversation
+            result = _load_prior_conversation("nonexistent")
+            assert result is None
+
+    def test_returns_messages_for_existing_session(self, db_session):
+        """Existing session returns {role, content} list."""
+        _seed_session_with_messages(db_session, "test-session", count=3)
+
+        with patch("src.db.connection.get_db_context", _mock_db_context(db_session)):
+            from src.services.conversation_handler import _load_prior_conversation
+            result = _load_prior_conversation("test-session")
+            assert result is not None
+            assert len(result) == 3
+            assert all("role" in m and "content" in m for m in result)
+
+    def test_returns_none_for_empty_messages(self, db_session):
+        """Session with no messages returns None."""
+        svc = ConversationPersistenceService(db_session)
+        svc.create_session(session_id="empty-session", mode="batch")
+
+        with patch("src.db.connection.get_db_context", _mock_db_context(db_session)):
+            from src.services.conversation_handler import _load_prior_conversation
+            result = _load_prior_conversation("empty-session")
+            assert result is None
+
+    def test_db_error_returns_none(self):
+        """Database error is caught and returns None."""
+        def failing_ctx():
+            raise RuntimeError("DB is down")
+
+        with patch("src.db.connection.get_db_context", failing_ctx):
+            from src.services.conversation_handler import _load_prior_conversation
+            result = _load_prior_conversation("any-session")
+            assert result is None
+
+
+class TestEnsureAgentPriorConversation:
+    """Verify ensure_agent loads prior conversation from DB."""
+
+    @pytest.mark.asyncio
+    async def test_new_session_passes_none_prior_conversation(self):
+        """A brand-new session with no DB history passes None to build_system_prompt."""
+        mock_session = MagicMock()
+        mock_session.agent = None
+        mock_session.agent_source_hash = None
+        mock_session.session_id = "new-session-no-db"
+
+        mock_agent_instance = AsyncMock()
+        mock_prompt = MagicMock(return_value="test prompt")
+
+        with patch("src.services.conversation_handler._load_prior_conversation", return_value=None), \
+             patch("src.services.conversation_handler._get_mru_contacts_for_prompt", return_value=[]), \
+             patch("src.orchestrator.agent.system_prompt.build_system_prompt", mock_prompt), \
+             patch("src.orchestrator.agent.client.OrchestrationAgent", return_value=mock_agent_instance):
+
+            from src.services.conversation_handler import ensure_agent
+            await ensure_agent(mock_session, source_info=None)
+
+            mock_prompt.assert_called_once()
+            call_kwargs = mock_prompt.call_args[1]
+            assert call_kwargs.get("prior_conversation") is None
+
+    @pytest.mark.asyncio
+    async def test_resumed_session_passes_prior_conversation(self, db_session):
+        """A session with DB history passes messages to build_system_prompt."""
+        _seed_session_with_messages(db_session, "resume-session", count=4)
+
+        mock_session = MagicMock()
+        mock_session.agent = None
+        mock_session.agent_source_hash = None
+        mock_session.session_id = "resume-session"
+
+        mock_agent_instance = AsyncMock()
+        mock_prompt = MagicMock(return_value="test prompt")
+
+        def mock_load(session_id):
+            """Simulate _load_prior_conversation reading from test DB."""
+            svc = ConversationPersistenceService(db_session)
+            result = svc.get_session_with_messages(session_id, limit=30)
+            if result is None or not result["messages"]:
+                return None
+            return [
+                {"role": m["role"], "content": m["content"]}
+                for m in result["messages"]
+            ]
+
+        with patch("src.services.conversation_handler._load_prior_conversation", side_effect=mock_load), \
+             patch("src.services.conversation_handler._get_mru_contacts_for_prompt", return_value=[]), \
+             patch("src.orchestrator.agent.system_prompt.build_system_prompt", mock_prompt), \
+             patch("src.orchestrator.agent.client.OrchestrationAgent", return_value=mock_agent_instance):
+
+            from src.services.conversation_handler import ensure_agent
+            await ensure_agent(mock_session, source_info=None)
+
+            mock_prompt.assert_called_once()
+            call_kwargs = mock_prompt.call_args[1]
+            prior = call_kwargs.get("prior_conversation")
+            assert prior is not None
+            assert len(prior) == 4
+            assert prior[0]["content"] == "Message 0"

--- a/tests/services/test_conversation_persistence_service.py
+++ b/tests/services/test_conversation_persistence_service.py
@@ -1,0 +1,167 @@
+"""Tests for ConversationPersistenceService."""
+
+import json
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+
+from src.db.models import Base, ConversationSession, MessageType
+from src.services.conversation_persistence_service import (
+    ConversationPersistenceService,
+)
+
+
+@pytest.fixture
+def db_session():
+    """In-memory SQLite for testing."""
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    SessionLocal = sessionmaker(bind=engine)
+    session = SessionLocal()
+    yield session
+    session.close()
+
+
+@pytest.fixture
+def svc(db_session: Session):
+    """Service under test."""
+    return ConversationPersistenceService(db_session)
+
+
+class TestCreateSession:
+    def test_creates_batch_session(self, svc, db_session):
+        sess = svc.create_session(session_id="test-1", mode="batch")
+        assert sess.id == "test-1"
+        assert sess.mode == "batch"
+        assert sess.is_active is True
+
+    def test_creates_interactive_session(self, svc, db_session):
+        sess = svc.create_session(session_id="test-2", mode="interactive")
+        assert sess.mode == "interactive"
+
+    def test_stores_context_data(self, svc, db_session):
+        ctx = {"data_source_id": "abc", "agent_source_hash": "xyz"}
+        sess = svc.create_session(
+            session_id="test-3", mode="batch", context_data=ctx,
+        )
+        loaded = json.loads(sess.context_data)
+        assert loaded["data_source_id"] == "abc"
+
+
+class TestSaveMessage:
+    def test_saves_user_message(self, svc, db_session):
+        svc.create_session(session_id="s1", mode="batch")
+        msg = svc.save_message("s1", role="user", content="Hello")
+        assert msg.role == "user"
+        assert msg.sequence == 1
+        assert msg.message_type == MessageType.text.value
+
+    def test_auto_increments_sequence(self, svc, db_session):
+        svc.create_session(session_id="s1", mode="batch")
+        m1 = svc.save_message("s1", role="user", content="First")
+        m2 = svc.save_message("s1", role="assistant", content="Second")
+        assert m1.sequence == 1
+        assert m2.sequence == 2
+
+    def test_saves_artifact_message(self, svc, db_session):
+        svc.create_session(session_id="s1", mode="batch")
+        metadata = {"action": "preview", "jobId": "j1"}
+        msg = svc.save_message(
+            "s1", role="system", content="Preview ready",
+            message_type=MessageType.system_artifact.value,
+            metadata=metadata,
+        )
+        assert msg.message_type == MessageType.system_artifact.value
+        loaded = json.loads(msg.metadata_json)
+        assert loaded["jobId"] == "j1"
+
+    def test_updates_session_updated_at(self, svc, db_session):
+        svc.create_session(session_id="s1", mode="batch")
+        svc.save_message("s1", role="user", content="test")
+        sess = db_session.get(ConversationSession,"s1")
+        assert sess.updated_at is not None
+
+
+class TestListSessions:
+    def test_lists_active_sessions(self, svc, db_session):
+        svc.create_session(session_id="s1", mode="batch")
+        svc.create_session(session_id="s2", mode="interactive")
+        svc.save_message("s1", role="user", content="msg")
+        results = svc.list_sessions()
+        assert len(results) == 2
+
+    def test_excludes_inactive(self, svc, db_session):
+        svc.create_session(session_id="s1", mode="batch")
+        svc.soft_delete_session("s1")
+        results = svc.list_sessions(active_only=True)
+        assert len(results) == 0
+
+    def test_includes_message_count(self, svc, db_session):
+        svc.create_session(session_id="s1", mode="batch")
+        svc.save_message("s1", role="user", content="a")
+        svc.save_message("s1", role="assistant", content="b")
+        results = svc.list_sessions()
+        assert results[0]["message_count"] == 2
+
+
+class TestGetSessionWithMessages:
+    def test_returns_ordered_messages(self, svc, db_session):
+        svc.create_session(session_id="s1", mode="batch")
+        svc.save_message("s1", role="user", content="first")
+        svc.save_message("s1", role="assistant", content="second")
+        result = svc.get_session_with_messages("s1")
+        assert result is not None
+        assert len(result["messages"]) == 2
+        assert result["messages"][0]["content"] == "first"
+        assert result["messages"][1]["content"] == "second"
+
+    def test_pagination(self, svc, db_session):
+        svc.create_session(session_id="s1", mode="batch")
+        for i in range(10):
+            svc.save_message("s1", role="user", content=f"msg {i}")
+        result = svc.get_session_with_messages("s1", limit=3, offset=2)
+        assert len(result["messages"]) == 3
+        assert result["messages"][0]["content"] == "msg 2"
+
+    def test_returns_none_for_missing(self, svc, db_session):
+        result = svc.get_session_with_messages("nonexistent")
+        assert result is None
+
+
+class TestUpdateTitle:
+    def test_updates_title(self, svc, db_session):
+        svc.create_session(session_id="s1", mode="batch")
+        svc.update_session_title("s1", "Ground Batch - Q3")
+        sess = db_session.get(ConversationSession,"s1")
+        assert sess.title == "Ground Batch - Q3"
+
+
+class TestUpdateContext:
+    def test_updates_context(self, svc, db_session):
+        svc.create_session(session_id="s1", mode="batch")
+        svc.update_session_context("s1", {"source": "new.csv"})
+        sess = db_session.get(ConversationSession,"s1")
+        loaded = json.loads(sess.context_data)
+        assert loaded["source"] == "new.csv"
+
+
+class TestSoftDelete:
+    def test_soft_deletes(self, svc, db_session):
+        svc.create_session(session_id="s1", mode="batch")
+        svc.soft_delete_session("s1")
+        sess = db_session.get(ConversationSession,"s1")
+        assert sess.is_active is False
+
+
+class TestExport:
+    def test_exports_full_session(self, svc, db_session):
+        svc.create_session(session_id="s1", mode="batch")
+        svc.save_message("s1", role="user", content="hello")
+        svc.save_message("s1", role="assistant", content="hi")
+        export = svc.export_session_json("s1")
+        assert export["session"]["id"] == "s1"
+        assert len(export["messages"]) == 2
+
+    def test_export_missing_returns_none(self, svc, db_session):
+        assert svc.export_session_json("nope") is None

--- a/tests/services/test_conversation_persistence_service.py
+++ b/tests/services/test_conversation_persistence_service.py
@@ -154,6 +154,16 @@ class TestSoftDelete:
         assert sess.is_active is False
 
 
+class TestTitleGeneration:
+    def test_title_updates_after_generation(self, svc, db_session):
+        svc.create_session(session_id="s1", mode="batch")
+        svc.save_message("s1", "user", "Ship all CA orders via Ground")
+        svc.save_message("s1", "assistant", "I'll help ship those orders.")
+        svc.update_session_title("s1", "Ground Batch - CA Orders")
+        sess = db_session.get(ConversationSession, "s1")
+        assert sess.title == "Ground Batch - CA Orders"
+
+
 class TestExport:
     def test_exports_full_session(self, svc, db_session):
         svc.create_session(session_id="s1", mode="batch")


### PR DESCRIPTION
## Summary

- **Database-backed chat persistence**: New `ConversationSession` and `ConversationMessage` SQLAlchemy models, `ConversationPersistenceService` with full CRUD, and REST API endpoints for listing, loading, deleting, exporting, and renaming sessions
- **Session resume via system prompt**: Prior conversation history injected into the agent's system prompt on session reload (token-budget truncated to 4,000 tokens), enabling context-aware continuation
- **Background title generation**: After the first assistant response, a fire-and-forget Haiku call generates a 3-6 word session title displayed in the sidebar
- **Frontend chat sessions panel**: Sidebar panel listing sessions grouped by Today/Yesterday/Previous 7 Days with load, delete, and new-chat actions
- **Visual timeline minimap**: Color-coded dot navigation (grey=user, cyan=assistant, amber=artifact, red=error) synced to scroll position via IntersectionObserver
- **Copy-to-clipboard on messages**: Hover-activated copy button with 1.5s checkmark feedback on all chat bubbles
- **Full wiring**: `CommandCenter` converted to `forwardRef` with `loadSession`/`newChat` imperative handle; `App.tsx` passes session callbacks through to Sidebar

## Test Plan

- [x] 39 new tests across 3 test files (models, persistence service, handler resume) — all pass
- [x] Full existing suite: 2,139 passed, 17 skipped, 0 failures
- [x] Frontend TypeScript compiles clean (`npx tsc --noEmit`)
- [ ] Manual: load a past session from sidebar, verify messages render and context restores
- [ ] Manual: verify timeline dots sync with scroll and click-to-scroll works
- [ ] Manual: verify copy button appears on hover, copies content, shows checkmark
- [ ] Manual: verify session title auto-generates after first assistant response
- [ ] Manual: verify export downloads JSON transcript