### PR TITLE
fix: prevent bare 500s on credential save by moving ConnectionService out of DI

### DIFF
--- a/tests/api/test_readyz_credentials.py
+++ b/tests/api/test_readyz_credentials.py
@@ -50,7 +50,12 @@ class TestReadyzCredentials:
         for var in ("UPS_CLIENT_ID", "UPS_CLIENT_SECRET", "UPS_ACCOUNT_NUMBER"):
             monkeypatch.delenv(var, raising=False)
 
-        resp = client.get("/readyz")
+        with patch(
+            "src.services.runtime_credentials.resolve_ups_credentials",
+            return_value=None,
+        ):
+            resp = client.get("/readyz")
+
         data = resp.json()
         assert data["checks"]["ups_credentials"]["status"] == "degraded"
         assert data["status"] == "degraded"


### PR DESCRIPTION
## Summary
- Root cause of HTTP 500 on credential save: `ConnectionService` construction in `Depends()` meant encryption key failures raised during FastAPI dependency injection — before the route's `try/except` could catch them
- All 5 route handlers now create `ConnectionService` inside `try/except` via `_build_service()` helper
- Added `_internal_error()` helper with full traceback logging (`exc_info=True`)
- Fixed `test_readyz_degraded_when_no_creds` to mock resolver for determinism
- 2 new regression tests verify structured JSON 500 on service init failure

## Test plan
- [x] 2553 tests pass, 0 failures
- [x] TypeScript compiles clean
- [x] New regression tests cover service construction failure path