### PR TITLE
feat: implement Auth0 account/provider authorization plane

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -60,6 +60,11 @@ SHIPAGENT_PUBLIC_BASE_URL=http://127.0.0.1:8080
 SHIPAGENT_DATABASE_URL=postgresql+asyncpg://shipagent:shipagent@127.0.0.1:5433/shipagent
 SHIPAGENT_REDIS_URL=redis://127.0.0.1:6380/0
 
+# Auth0-backed control plane settings
+SHIPAGENT_AUTH0_ISSUER=https://shipagent-dev.us.auth0.com/
+SHIPAGENT_AUTH0_AUDIENCE=https://dev-mcp.shipagent.app
+SHIPAGENT_AUTH0_PROVIDER_CLIENTS={"chatgpt-client":"chatgpt","claude-client":"claude_ai","desktop-client":"desktop","operator-client":"operator"}
+
 # =============================================================================
 # Shopify MCP Configuration
 # =============================================================================

--- a/docs/integrations/auth0-provider-clients.md
+++ b/docs/integrations/auth0-provider-clients.md
@@ -1,0 +1,40 @@
+# Auth0 Provider Clients (Internal Prototype)
+
+This page defines the fixed Auth0 client set for the internal ShipAgent MCP
+resource prototype and their OAuth surface expectations.
+
+## Fixed MCP Resource
+
+- OAuth resource: `https://dev-mcp.shipagent.app`
+
+## Client Settings
+
+| Client | Auth Flow | Secret | Notes |
+| --- | --- | --- | --- |
+| ChatGPT | Authorization Code + PKCE | No (public) | Maps to `client_id: chatgpt-client` and Surface `chatgpt`. |
+| Claude.ai | Authorization Code + PKCE | No (public) | Maps to `client_id: claude-client` and Surface `claude_ai`. |
+| Desktop | Device Authorization Grant | No (public desktop app) | Maps to `client_id: desktop-client` and Surface `desktop`. |
+| Operator | Authorization Code + PKCE (web app) with MFA | Yes (confidential) | Maps to `client_id: operator-client` and Surface `operator`. Uses separate runtime audience for desktop-independent operator workflows. |
+
+## Environment Mapping
+
+Set `SHIPAGENT_AUTH0_PROVIDER_CLIENTS` as:
+
+```json
+{"chatgpt-client":"chatgpt","claude-client":"claude_ai","desktop-client":"desktop","operator-client":"operator"}
+```
+
+and configure:
+
+- `SHIPAGENT_AUTH0_ISSUER`
+- `SHIPAGENT_AUTH0_AUDIENCE` (currently `https://dev-mcp.shipagent.app`)
+
+## Validation
+
+Use:
+
+```bash
+.venv/bin/python scripts/check_provider_oauth_metadata.py https://dev-mcp.shipagent.app
+```
+
+This only verifies the metadata shape and does not output tokens or credentials.

--- a/scripts/check_provider_oauth_metadata.py
+++ b/scripts/check_provider_oauth_metadata.py
@@ -6,6 +6,8 @@ import sys
 
 import httpx
 
+from src.control_plane.routes.oauth_metadata import SUPPORTED_SCOPES
+
 
 def check_metadata(base_url: str) -> dict[str, object]:
     response = httpx.get(
@@ -22,6 +24,8 @@ def check_metadata(base_url: str) -> dict[str, object]:
         )
     if not payload.get("authorization_servers"):
         raise RuntimeError("metadata missing authorization_servers")
+    if sorted(payload.get("scopes_supported", [])) != sorted(SUPPORTED_SCOPES):
+        raise RuntimeError("metadata scopes_supported mismatch")
 
     return payload
 

--- a/scripts/check_provider_oauth_metadata.py
+++ b/scripts/check_provider_oauth_metadata.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""Validate hosted MCP OAuth protected-resource metadata."""
+
+import json
+import sys
+
+import httpx
+
+
+def check_metadata(base_url: str) -> dict[str, object]:
+    response = httpx.get(
+        f"{base_url.rstrip('/')}/.well-known/oauth-protected-resource",
+        timeout=10,
+    )
+    response.raise_for_status()
+    payload = response.json()
+
+    resource = base_url.rstrip("/")
+    if payload.get("resource") != resource:
+        raise RuntimeError(
+            f"metadata resource mismatch: {payload.get('resource')} != {resource}"
+        )
+    if not payload.get("authorization_servers"):
+        raise RuntimeError("metadata missing authorization_servers")
+
+    return payload
+
+
+def main(argv: list[str]) -> None:
+    if len(argv) != 2:
+        raise SystemExit("usage: python scripts/check_provider_oauth_metadata.py <base_url>")
+    payload = check_metadata(argv[1])
+    print(f"metadata check passed for {argv[1]}")
+    print(json.dumps(payload, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main(sys.argv)

--- a/src/control_plane/app.py
+++ b/src/control_plane/app.py
@@ -6,14 +6,14 @@ from redis.asyncio import from_url as redis_from_url
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from src.control_plane.auth import (
-    AuthorizationService,
     Auth0TokenVerifier,
+    AuthorizationService,
     ProviderClientRegistry,
     clear_authorization_context,
     set_authorization_context,
 )
-from src.control_plane.auth.jwt_verifier import TokenPrincipal
 from src.control_plane.auth.context import AuthorizationContext
+from src.control_plane.auth.jwt_verifier import TokenPrincipal
 from src.control_plane.config import ControlPlaneSettings
 from src.control_plane.routes.oauth_metadata import build_metadata_router
 from src.control_plane.request_controls import RequestControls
@@ -63,11 +63,9 @@ async def _resolve_authorization(
         )
 
 
-def _build_verifier(settings: ControlPlaneSettings) -> Auth0TokenVerifier:
-    return Auth0TokenVerifier(
-        issuer=settings.auth0_issuer,
-        audience=settings.auth0_audience,
-    )
+@lru_cache
+def _build_verifier(issuer: str, audience: str) -> Auth0TokenVerifier:
+    return Auth0TokenVerifier(issuer=issuer, audience=audience)
 
 
 def create_control_plane_app() -> FastAPI:
@@ -83,11 +81,10 @@ def create_control_plane_app() -> FastAPI:
     mcp = build_server(request_controls=_build_request_controls(settings))
     mcp_app = mcp.http_app(path="/", transport="streamable-http")
     app = FastAPI(lifespan=mcp_app.lifespan)
+    verifier = _build_verifier(settings.auth0_issuer, settings.auth0_audience)
+    metadata_resource = _metadata_url(settings)
     app.include_router(
-        build_metadata_router(
-            str(settings.public_base_url),
-            settings.auth0_issuer,
-        )
+        build_metadata_router(metadata_resource, settings.auth0_issuer)
     )
     app.mount("/mcp", mcp_app)
 
@@ -113,21 +110,19 @@ def create_control_plane_app() -> FastAPI:
             )
 
         try:
-            verifier = _build_verifier(settings)
             principal = verifier.verify(token)
             context = await _resolve_authorization(settings, principal)
-            token_state = set_authorization_context(context)
+            context_token = set_authorization_context(context)
             request.state.authorization = context
-            try:
-                response = await call_next(request)
-            finally:
-                clear_authorization_context(token_state)
-            return response
-        except PermissionError:
+        except Exception:
             return JSONResponse(
                 status_code=401,
                 content={"detail": "Unauthorized"},
                 headers=_bearer_challenge(settings),
             )
+        try:
+            return await call_next(request)
+        finally:
+            clear_authorization_context(context_token)
 
     return app

--- a/src/control_plane/app.py
+++ b/src/control_plane/app.py
@@ -15,7 +15,7 @@ from src.control_plane.auth import (
 from src.control_plane.auth.context import AuthorizationContext
 from src.control_plane.auth.jwt_verifier import TokenPrincipal
 from src.control_plane.config import ControlPlaneSettings
-from src.control_plane.hosted_mcp.server import build_server
+from src.hosted_mcp.server import build_server
 from src.control_plane.request_controls import RequestControls
 from src.control_plane.routes.oauth_metadata import build_metadata_router
 from src.control_plane.startup import validate_startup_security

--- a/src/control_plane/app.py
+++ b/src/control_plane/app.py
@@ -1,0 +1,133 @@
+from functools import lru_cache
+
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+from redis.asyncio import from_url as redis_from_url
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from src.control_plane.auth import (
+    AuthorizationService,
+    Auth0TokenVerifier,
+    ProviderClientRegistry,
+    clear_authorization_context,
+    set_authorization_context,
+)
+from src.control_plane.auth.jwt_verifier import TokenPrincipal
+from src.control_plane.auth.context import AuthorizationContext
+from src.control_plane.config import ControlPlaneSettings
+from src.control_plane.routes.oauth_metadata import build_metadata_router
+from src.control_plane.request_controls import RequestControls
+from src.control_plane.startup import validate_startup_security
+from src.hosted_mcp.server import build_server
+
+
+@lru_cache
+def _build_db_sessionmaker(database_url: str) -> async_sessionmaker[AsyncSession]:
+    engine = create_async_engine(database_url)
+    return async_sessionmaker(engine, expire_on_commit=False)
+
+
+def _build_redis_client(redis_url: str):
+    return redis_from_url(redis_url, decode_responses=False)
+
+
+def _metadata_url(settings: ControlPlaneSettings) -> str:
+    if settings.public_base_url is None:
+        raise RuntimeError("SHIPAGENT_PUBLIC_BASE_URL is required for OAuth metadata")
+    return f"{str(settings.public_base_url).rstrip('/')}/.well-known/oauth-protected-resource"
+
+
+def _bearer_challenge(settings: ControlPlaneSettings) -> dict[str, str]:
+    return {
+        "WWW-Authenticate": (
+            f'Bearer resource_metadata="{_metadata_url(settings)}"'
+        )
+    }
+
+
+def _build_request_controls(settings: ControlPlaneSettings) -> RequestControls:
+    return RequestControls(redis_client=_build_redis_client(settings.redis_url))
+
+
+async def _resolve_authorization(
+    settings: ControlPlaneSettings,
+    principal: TokenPrincipal,
+) -> AuthorizationContext:
+    client_registry = ProviderClientRegistry(settings.auth0_provider_clients)
+    async with _build_db_sessionmaker(settings.database_url)() as session:
+        service = AuthorizationService(session, client_registry)
+        return await service.resolve(
+            subject=principal.subject,
+            client_id=principal.client_id,
+            scopes=set(principal.scopes),
+        )
+
+
+def _build_verifier(settings: ControlPlaneSettings) -> Auth0TokenVerifier:
+    return Auth0TokenVerifier(
+        issuer=settings.auth0_issuer,
+        audience=settings.auth0_audience,
+    )
+
+
+def create_control_plane_app() -> FastAPI:
+    settings = ControlPlaneSettings()
+    validate_startup_security(settings)
+    if not settings.auth0_issuer:
+        raise RuntimeError("SHIPAGENT_AUTH0_ISSUER must be set")
+    if not settings.auth0_audience:
+        raise RuntimeError("SHIPAGENT_AUTH0_AUDIENCE must be set")
+    if not settings.public_base_url:
+        raise RuntimeError("SHIPAGENT_PUBLIC_BASE_URL must be set")
+
+    mcp = build_server(request_controls=_build_request_controls(settings))
+    mcp_app = mcp.http_app(path="/", transport="streamable-http")
+    app = FastAPI(lifespan=mcp_app.lifespan)
+    app.include_router(
+        build_metadata_router(
+            str(settings.public_base_url),
+            settings.auth0_issuer,
+        )
+    )
+    app.mount("/mcp", mcp_app)
+
+    @app.middleware("http")
+    async def _require_authorization(request: Request, call_next):
+        if request.url.path.startswith("/.well-known/oauth-protected-resource"):
+            return await call_next(request)
+
+        authorization = request.headers.get("authorization", "")
+        if not authorization.lower().startswith("bearer "):
+            return JSONResponse(
+                status_code=401,
+                content={"detail": "Unauthorized"},
+                headers=_bearer_challenge(settings),
+            )
+
+        token = authorization.split(" ", 1)[1].strip()
+        if not token:
+            return JSONResponse(
+                status_code=401,
+                content={"detail": "Unauthorized"},
+                headers=_bearer_challenge(settings),
+            )
+
+        try:
+            verifier = _build_verifier(settings)
+            principal = verifier.verify(token)
+            context = await _resolve_authorization(settings, principal)
+            token_state = set_authorization_context(context)
+            request.state.authorization = context
+            try:
+                response = await call_next(request)
+            finally:
+                clear_authorization_context(token_state)
+            return response
+        except PermissionError:
+            return JSONResponse(
+                status_code=401,
+                content={"detail": "Unauthorized"},
+                headers=_bearer_challenge(settings),
+            )
+
+    return app

--- a/src/control_plane/app.py
+++ b/src/control_plane/app.py
@@ -15,10 +15,10 @@ from src.control_plane.auth import (
 from src.control_plane.auth.context import AuthorizationContext
 from src.control_plane.auth.jwt_verifier import TokenPrincipal
 from src.control_plane.config import ControlPlaneSettings
-from src.hosted_mcp.server import build_server
 from src.control_plane.request_controls import RequestControls
 from src.control_plane.routes.oauth_metadata import build_metadata_router
 from src.control_plane.startup import validate_startup_security
+from src.hosted_mcp.server import build_server
 
 
 @lru_cache

--- a/src/control_plane/app.py
+++ b/src/control_plane/app.py
@@ -15,10 +15,10 @@ from src.control_plane.auth import (
 from src.control_plane.auth.context import AuthorizationContext
 from src.control_plane.auth.jwt_verifier import TokenPrincipal
 from src.control_plane.config import ControlPlaneSettings
-from src.control_plane.routes.oauth_metadata import build_metadata_router
+from src.control_plane.hosted_mcp.server import build_server
 from src.control_plane.request_controls import RequestControls
+from src.control_plane.routes.oauth_metadata import build_metadata_router
 from src.control_plane.startup import validate_startup_security
-from src.hosted_mcp.server import build_server
 
 
 @lru_cache
@@ -82,7 +82,7 @@ def create_control_plane_app() -> FastAPI:
     mcp_app = mcp.http_app(path="/", transport="streamable-http")
     app = FastAPI(lifespan=mcp_app.lifespan)
     verifier = _build_verifier(settings.auth0_issuer, settings.auth0_audience)
-    metadata_resource = _metadata_url(settings)
+    metadata_resource = str(settings.public_base_url).rstrip("/")
     app.include_router(
         build_metadata_router(metadata_resource, settings.auth0_issuer)
     )

--- a/src/control_plane/auth/__init__.py
+++ b/src/control_plane/auth/__init__.py
@@ -1,0 +1,22 @@
+"""Auth helpers for the control-plane authorization flow."""
+
+from .context import (
+    AuthorizationContext,
+    clear_authorization_context,
+    get_authorization_context,
+    set_authorization_context,
+)
+from .jwt_verifier import Auth0TokenVerifier, TokenPrincipal
+from .provider_clients import ProviderClientRegistry
+from .service import AuthorizationService
+
+__all__ = [
+    "AuthorizationContext",
+    "Auth0TokenVerifier",
+    "TokenPrincipal",
+    "ProviderClientRegistry",
+    "AuthorizationService",
+    "clear_authorization_context",
+    "get_authorization_context",
+    "set_authorization_context",
+]

--- a/src/control_plane/auth/context.py
+++ b/src/control_plane/auth/context.py
@@ -1,0 +1,32 @@
+from contextvars import ContextVar
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class AuthorizationContext:
+    account_id: str
+    provider_connection_id: str
+    provider_surface: str
+    subject: str
+    client_id: str
+    scopes: frozenset[str]
+
+
+_AUTHORIZATION_CONTEXT: ContextVar[AuthorizationContext | None] = ContextVar(
+    "authorization_context", default=None
+)
+
+
+def get_authorization_context() -> AuthorizationContext | None:
+    """Return the current request authorization context, if set."""
+    return _AUTHORIZATION_CONTEXT.get()
+
+
+def set_authorization_context(context: AuthorizationContext | None):
+    """Set the current request authorization context."""
+    return _AUTHORIZATION_CONTEXT.set(context)
+
+
+def clear_authorization_context(token) -> None:
+    """Reset the authorization context context manager token."""
+    _AUTHORIZATION_CONTEXT.reset(token)

--- a/src/control_plane/auth/jwt_verifier.py
+++ b/src/control_plane/auth/jwt_verifier.py
@@ -1,0 +1,65 @@
+from dataclasses import dataclass
+from typing import Any
+
+import jwt
+from jwt import PyJWKClient, PyJWKClientError
+
+
+@dataclass(frozen=True)
+class TokenPrincipal:
+    subject: str
+    client_id: str
+    scopes: frozenset[str]
+
+
+class Auth0TokenVerifier:
+    def __init__(self, issuer: str, audience: str, jwks_client=None) -> None:
+        self.issuer = issuer.rstrip("/") + "/"
+        self.audience = audience
+        self.jwks_client = jwks_client or PyJWKClient(f"{self.issuer}.well-known/jwks.json")
+
+    def verify(self, token: str) -> TokenPrincipal:
+        try:
+            key = self.jwks_client.get_signing_key_from_jwt(token).key
+            claims = jwt.decode(
+                token,
+                key,
+                algorithms=["RS256"],
+                audience=self.audience,
+                issuer=self.issuer,
+                options={"require": ["exp", "iat", "iss", "aud", "sub"]},
+            )
+            return self.validate_claims(claims)
+        except (jwt.InvalidTokenError, PyJWKClientError) as exc:
+            raise PermissionError("invalid access token") from exc
+
+    def validate_claims(self, claims: dict[str, Any]) -> TokenPrincipal:
+        if claims.get("iss") != self.issuer:
+            raise PermissionError("invalid token issuer")
+        audience = claims.get("aud")
+        if isinstance(audience, str):
+            if audience != self.audience:
+                raise PermissionError("invalid token audience")
+        elif isinstance(audience, list):
+            if self.audience not in audience:
+                raise PermissionError("invalid token audience")
+        else:
+            raise PermissionError("invalid token audience")
+
+        subject = claims.get("sub")
+        client_id = claims.get("azp") or claims.get("client_id")
+        if (
+            not isinstance(subject, str)
+            or not isinstance(client_id, str)
+            or not subject.strip()
+            or not client_id.strip()
+        ):
+            raise PermissionError("token identity claims are incomplete")
+
+        scope_claim = claims.get("scope", "")
+        if isinstance(scope_claim, str):
+            scopes = frozenset(scope_claim.split())
+        else:
+            scopes = frozenset()
+
+        return TokenPrincipal(subject=subject, client_id=client_id, scopes=scopes)

--- a/src/control_plane/auth/provider_clients.py
+++ b/src/control_plane/auth/provider_clients.py
@@ -1,0 +1,15 @@
+from types import MappingProxyType
+
+
+class ProviderClientRegistry:
+    """Map Auth0 OAuth client IDs to provider surfaces."""
+
+    def __init__(self, clients: dict[str, str]) -> None:
+        self._clients = MappingProxyType(dict(clients))
+
+    def surface_for(self, client_id: str) -> str:
+        """Resolve a trusted provider surface for an Auth0 client ID."""
+        surface = self._clients.get(client_id)
+        if surface is None:
+            raise PermissionError("token was not issued to an authorized provider client")
+        return surface

--- a/src/control_plane/auth/service.py
+++ b/src/control_plane/auth/service.py
@@ -1,0 +1,59 @@
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.control_plane.auth.context import AuthorizationContext
+from src.control_plane.auth.provider_clients import ProviderClientRegistry
+from src.control_plane.models import CloudAccount, ProviderConnection
+
+
+class AuthorizationService:
+    def __init__(
+        self, db: AsyncSession, clients: ProviderClientRegistry
+    ) -> None:
+        self.db = db
+        self.clients = clients
+
+    async def resolve(
+        self, *, subject: str, client_id: str, scopes: set[str]
+    ) -> AuthorizationContext:
+        surface = self.clients.surface_for(client_id)
+        account = await self.db.scalar(
+            select(CloudAccount).where(CloudAccount.auth0_subject == subject)
+        )
+        if account is None:
+            account = CloudAccount(auth0_subject=subject)
+            self.db.add(account)
+            await self.db.flush()
+
+        if account.suspended:
+            raise PermissionError("ShipAgent Cloud Account is suspended")
+
+        connection = await self.db.scalar(
+            select(ProviderConnection).where(
+                ProviderConnection.account_id == account.id,
+                ProviderConnection.client_id == client_id,
+                ProviderConnection.surface == surface,
+            )
+        )
+        if connection is None:
+            connection = ProviderConnection(
+                account_id=account.id,
+                client_id=client_id,
+                surface=surface,
+                status="active",
+            )
+            self.db.add(connection)
+
+        if connection.status != "active":
+            raise PermissionError("Provider Connection is not active")
+
+        connection.scopes_text = " ".join(sorted(scopes))
+        await self.db.commit()
+        return AuthorizationContext(
+            account_id=account.id,
+            provider_connection_id=connection.id,
+            provider_surface=surface,
+            subject=subject,
+            client_id=client_id,
+            scopes=frozenset(scopes),
+        )

--- a/src/control_plane/config.py
+++ b/src/control_plane/config.py
@@ -28,4 +28,11 @@ class ControlPlaneSettings(BaseSettings):
     auth0_issuer: str = ""
     auth0_audience: str = ""
     relay_signing_secret: str = Field(default="", min_length=0)
-
+    auth0_provider_clients: dict[str, str] = Field(
+        default_factory=lambda: {
+            "chatgpt-client": "chatgpt",
+            "claude-client": "claude_ai",
+            "desktop-client": "desktop",
+            "operator-client": "operator",
+        }
+    )

--- a/src/control_plane/redis_keys.py
+++ b/src/control_plane/redis_keys.py
@@ -23,3 +23,11 @@ class RedisKey:
     @staticmethod
     def provider_poll(connection_id: str, reference: str) -> str:
         return f"sa:poll:{connection_id}:{reference}"
+
+    @staticmethod
+    def rate_limit(connection_id: str, rate_limit_class: str, minute_bucket: str) -> str:
+        return f"sa:rate:{connection_id}:{rate_limit_class}:{minute_bucket}"
+
+    @staticmethod
+    def loop_guard(connection_id: str, tool_name: str, arguments_hash: str) -> str:
+        return f"sa:loop:{connection_id}:{tool_name}:{arguments_hash}"

--- a/src/control_plane/request_controls.py
+++ b/src/control_plane/request_controls.py
@@ -28,9 +28,9 @@ def _canonicalize_argument_value(value):
             key: (
                 "[redacted]"
                 if key.lower() in _SENSITIVE_ARGUMENT_KEYS
-                else _canonicalize_argument_value(value[key])
+                else _canonicalize_argument_value(val)
             )
-            for key, value in value.items()
+            for key, val in value.items()
         }
     if isinstance(value, list):
         return [_canonicalize_argument_value(item) for item in value]
@@ -63,7 +63,7 @@ def hash_arguments(arguments: Mapping[str, object]) -> str:
     return hashlib.sha256(serialized.encode("utf-8")).hexdigest()
 
 
-@dataclass(frozen=True)
+@dataclass
 class RequestControlError(PermissionError):
     code: str
     message: str

--- a/src/control_plane/request_controls.py
+++ b/src/control_plane/request_controls.py
@@ -1,0 +1,170 @@
+import hashlib
+import json
+import time
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+from src.control_plane.redis_keys import RedisKey
+
+DEFAULT_WINDOW_SECONDS = 60
+LOOP_DETECTION_LIMIT = 3
+
+RATE_LIMIT_BY_CLASS: dict[str, int] = {
+    "default": 10,
+    "read": 30,
+    "estimate": 10,
+    "write": 20,
+    "purchase": 5,
+}
+
+
+def _normalize_rate_limit_class(rate_limit_class: str | None) -> str:
+    return rate_limit_class if rate_limit_class in RATE_LIMIT_BY_CLASS else "default"
+
+
+def _canonicalize_argument_value(value):
+    if isinstance(value, dict):
+        return {
+            key: (
+                "[redacted]"
+                if key.lower() in _SENSITIVE_ARGUMENT_KEYS
+                else _canonicalize_argument_value(value[key])
+            )
+            for key, value in value.items()
+        }
+    if isinstance(value, list):
+        return [_canonicalize_argument_value(item) for item in value]
+    if isinstance(value, tuple):
+        return [_canonicalize_argument_value(item) for item in value]
+    return value
+
+
+_SENSITIVE_ARGUMENT_KEYS = frozenset(
+    {
+        "secret",
+        "api_secret",
+        "api_key",
+        "access_token",
+        "token",
+        "password",
+        "provider_file_url",
+        "file_url",
+    }
+)
+
+
+def hash_arguments(arguments: Mapping[str, object]) -> str:
+    normalized = _canonicalize_argument_value(dict(arguments))
+    serialized = json.dumps(
+        normalized,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return hashlib.sha256(serialized.encode("utf-8")).hexdigest()
+
+
+@dataclass(frozen=True)
+class RequestControlError(PermissionError):
+    code: str
+    message: str
+    retry_after_seconds: int | None = None
+
+    def __str__(self) -> str:
+        if self.retry_after_seconds is None:
+            return self.message
+        return f"{self.message} (retry_after={self.retry_after_seconds})"
+
+
+class RequestControls:
+    """Redis-backed request controls for rate and loop protection."""
+
+    _RATE_LIMIT_LUA = """
+    -- SA_RATE_LIMIT
+    local key = KEYS[1]
+    local limit = tonumber(ARGV[1])
+    local ttl = tonumber(ARGV[2])
+    local count = redis.call('INCR', key)
+    if count == 1 then
+        redis.call('EXPIRE', key, ttl)
+    end
+    return count
+    """
+
+    _LOOP_GUARD_LUA = """
+    -- SA_LOOP_GUARD
+    local key = KEYS[1]
+    local ttl = tonumber(ARGV[1])
+    local count = redis.call('INCR', key)
+    if count == 1 then
+        redis.call('EXPIRE', key, ttl)
+    end
+    return count
+    """
+
+    def __init__(self, redis_client, now_fn=None) -> None:
+        self.redis = redis_client
+        self._now = now_fn or time.time
+
+    async def require_allowed(
+        self,
+        *,
+        connection_id: str,
+        tool_name: str,
+        rate_limit_class: str,
+        arguments_hash: str,
+    ) -> None:
+        await self._require_rate_limit(
+            connection_id=connection_id,
+            rate_limit_class=rate_limit_class,
+        )
+        await self._require_loop_guard(
+            connection_id=connection_id,
+            tool_name=tool_name,
+            arguments_hash=arguments_hash,
+        )
+
+    async def _require_rate_limit(
+        self,
+        *,
+        connection_id: str,
+        rate_limit_class: str,
+    ) -> None:
+        normalized_class = _normalize_rate_limit_class(rate_limit_class)
+        limit = RATE_LIMIT_BY_CLASS[normalized_class]
+        minute_bucket = int(self._now() // DEFAULT_WINDOW_SECONDS)
+        key = RedisKey.rate_limit(
+            connection_id,
+            normalized_class,
+            str(minute_bucket),
+        )
+
+        count = int(await self.redis.eval(self._RATE_LIMIT_LUA, 1, key, str(limit), str(DEFAULT_WINDOW_SECONDS)))
+        if count > limit:
+            elapsed = int(self._now() % DEFAULT_WINDOW_SECONDS)
+            raise RequestControlError(
+                code="rate_limited",
+                message="rate limit exceeded",
+                retry_after_seconds=DEFAULT_WINDOW_SECONDS - elapsed,
+            )
+
+    async def _require_loop_guard(
+        self,
+        *,
+        connection_id: str,
+        tool_name: str,
+        arguments_hash: str,
+    ) -> None:
+        key = RedisKey.loop_guard(connection_id, tool_name, arguments_hash)
+        count = int(
+            await self.redis.eval(
+                self._LOOP_GUARD_LUA,
+                1,
+                key,
+                str(DEFAULT_WINDOW_SECONDS),
+            )
+        )
+        if count > LOOP_DETECTION_LIMIT:
+            raise RequestControlError(
+                code="provider_loop_detected",
+                message="identical call loop detected",
+            )

--- a/src/control_plane/routes/oauth_metadata.py
+++ b/src/control_plane/routes/oauth_metadata.py
@@ -1,0 +1,26 @@
+from typing import Final
+
+from fastapi import APIRouter
+
+SUPPORTED_SCOPES: Final = [
+    "status:read",
+    "shipments:preview",
+    "shipments:create",
+    "jobs:read",
+    "labels:read",
+]
+
+
+def build_metadata_router(resource: str, issuer: str) -> APIRouter:
+    router = APIRouter()
+
+    @router.get("/.well-known/oauth-protected-resource")
+    async def protected_resource_metadata() -> dict[str, object]:
+        return {
+            "resource": resource,
+            "authorization_servers": [issuer.rstrip("/") + "/"],
+            "scopes_supported": SUPPORTED_SCOPES,
+            "bearer_methods_supported": ["header"],
+        }
+
+    return router

--- a/src/hosted_mcp/server.py
+++ b/src/hosted_mcp/server.py
@@ -10,26 +10,88 @@ from fastmcp.tools import Tool
 from fastmcp.tools.tool import ToolResult
 from mcp.types import TextContent, ToolAnnotations
 
+from src.control_plane.auth.context import AuthorizationContext, get_authorization_context
+from src.control_plane.request_controls import (
+    RequestControlError,
+    RequestControls,
+    hash_arguments,
+)
 from src.provider_adapters.export_filter import exportable_tools
 from src.provider_adapters.mcp_projection import to_mcp_tool_descriptor
 from src.control_plane.result_projection import project_result
-from src.registry.models import ProviderExport, ToolContract
+from src.registry.models import ToolContract, ProviderExport
 
-ToolHandler = Callable[[dict[str, Any]], Awaitable[dict[str, Any]] | dict[str, Any]]
+ToolHandler = Callable[
+    [AuthorizationContext, dict[str, Any]],
+    Awaitable[dict[str, Any]] | dict[str, Any],
+]
 
 
 class BoundRegistryTool(Tool):
     def __init__(
-        self, *args: Any, contract: ToolContract, handler: ToolHandler, **kwargs: Any
+        self,
+        *args: Any,
+        contract: ToolContract,
+        handler: ToolHandler,
+        request_controls: RequestControls | None = None,
+        **kwargs: Any,
     ) -> None:
         super().__init__(*args, **kwargs)
         object.__setattr__(self, "_contract", contract)
         object.__setattr__(self, "_handler", handler)
+        object.__setattr__(self, "_request_controls", request_controls)
+
+    @staticmethod
+    def _context_missing_error() -> "ToolAuthorizationError":
+        return ToolAuthorizationError(
+            code="missing_authorization_context",
+            message="authorization context unavailable",
+        )
+
+    @staticmethod
+    def _missing_scopes_error(required_scopes: list[str]) -> "ToolAuthorizationError":
+        return ToolAuthorizationError(
+            code="insufficient_scope",
+            message="insufficient scopes",
+            required_scopes=required_scopes,
+        )
+
+    @staticmethod
+    def _loop_guard_or_rate_limit_error(
+        err: RequestControlError,
+    ) -> "ToolAuthorizationError":
+        return ToolAuthorizationError(
+            code=err.code,
+            message=err.message,
+            retry_after_seconds=err.retry_after_seconds,
+        )
 
     async def run(self, arguments: dict[str, Any]) -> ToolResult:
-        result = self._handler(arguments)
+        context = get_authorization_context()
+        if context is None:
+            raise self._context_missing_error()
+
+        missing = set(self._contract.auth_scopes) - context.scopes
+        if missing:
+            raise self._missing_scopes_error(sorted(missing))
+
+        request_controls = getattr(self, "_request_controls", None)
+        if request_controls is not None:
+            try:
+                arguments_hash = hash_arguments(arguments)
+                await request_controls.require_allowed(
+                    connection_id=context.provider_connection_id,
+                    tool_name=self._contract.name,
+                    rate_limit_class=self._contract.rate_limit_class,
+                    arguments_hash=arguments_hash,
+                )
+            except RequestControlError as err:
+                raise self._loop_guard_or_rate_limit_error(err)
+
+        result = self._handler(context, arguments)
         if inspect.isawaitable(result):
             result = await result
+
         result = project_result(self._contract, result)
         return ToolResult(
             content=[
@@ -45,6 +107,7 @@ class BoundRegistryTool(Tool):
 def build_server(
     tool_handlers: Mapping[str, ToolHandler] | None = None,
     tools: Iterable[ToolContract] | None = None,
+    request_controls: RequestControls | None = None,
 ) -> FastMCP:
     server = FastMCP("ShipAgentHosted")
     handlers = tool_handlers or {}
@@ -55,14 +118,32 @@ def build_server(
         descriptor = to_mcp_tool_descriptor(tool)
         server.add_tool(
             BoundRegistryTool(
-            name=tool.name,
-            title=tool.title,
-            description=tool.description,
-            parameters=descriptor["inputSchema"],
-            output_schema=descriptor["outputSchema"],
-            annotations=ToolAnnotations(**descriptor["annotations"]),
-            contract=tool,
-            handler=handler,
-        )
+                name=tool.name,
+                title=tool.title,
+                description=tool.description,
+                parameters=descriptor["inputSchema"],
+                output_schema=descriptor["outputSchema"],
+                annotations=ToolAnnotations(**descriptor["annotations"]),
+                contract=tool,
+                handler=handler,
+                request_controls=request_controls,
+            )
         )
     return server
+
+
+class ToolAuthorizationError(PermissionError):
+    """Raised when tool invocation cannot be authorized."""
+
+    def __init__(
+        self,
+        *,
+        code: str,
+        message: str,
+        required_scopes: list[str] | None = None,
+        retry_after_seconds: int | None = None,
+    ) -> None:
+        self.code = code
+        self.required_scopes = required_scopes
+        self.retry_after_seconds = retry_after_seconds
+        super().__init__(message)

--- a/tests/control_plane/auth/test_jwt_verifier.py
+++ b/tests/control_plane/auth/test_jwt_verifier.py
@@ -1,0 +1,40 @@
+import pytest
+
+from src.control_plane.auth.jwt_verifier import Auth0TokenVerifier
+
+
+def test_claim_validation_requires_issuer_audience_subject_client_and_scope():
+    verifier = Auth0TokenVerifier(
+        issuer="https://tenant.us.auth0.com/",
+        audience="https://dev-mcp.shipagent.app",
+        jwks_client=None,
+    )
+    claims = {
+        "iss": "https://tenant.us.auth0.com/",
+        "aud": "https://dev-mcp.shipagent.app",
+        "sub": "auth0|owner-1",
+        "azp": "chatgpt-client",
+        "scope": "shipments:preview jobs:read",
+    }
+    principal = verifier.validate_claims(claims)
+    assert principal.client_id == "chatgpt-client"
+    assert principal.scopes == frozenset({"shipments:preview", "jobs:read"})
+
+
+@pytest.mark.parametrize("field", ["iss", "aud", "sub", "azp"])
+def test_missing_or_wrong_required_claim_fails(field):
+    claims = {
+        "iss": "https://tenant.us.auth0.com/",
+        "aud": "https://dev-mcp.shipagent.app",
+        "sub": "auth0|owner-1",
+        "azp": "chatgpt-client",
+        "scope": "jobs:read",
+    }
+    claims.pop(field)
+    verifier = Auth0TokenVerifier(
+        issuer="https://tenant.us.auth0.com/",
+        audience="https://dev-mcp.shipagent.app",
+        jwks_client=None,
+    )
+    with pytest.raises(PermissionError):
+        verifier.validate_claims(claims)

--- a/tests/control_plane/auth/test_provider_clients.py
+++ b/tests/control_plane/auth/test_provider_clients.py
@@ -1,0 +1,16 @@
+import pytest
+
+from src.control_plane.auth.provider_clients import ProviderClientRegistry
+
+
+def test_known_client_resolves_surface():
+    registry = ProviderClientRegistry(
+        {"chatgpt-client": "chatgpt", "claude-client": "claude_ai"}
+    )
+    assert registry.surface_for("chatgpt-client") == "chatgpt"
+
+
+def test_unknown_client_fails_closed():
+    registry = ProviderClientRegistry({"chatgpt-client": "chatgpt"})
+    with pytest.raises(PermissionError, match="authorized provider client"):
+        registry.surface_for("unknown")

--- a/tests/control_plane/auth/test_service.py
+++ b/tests/control_plane/auth/test_service.py
@@ -1,7 +1,6 @@
 import pytest
 from sqlalchemy import select
 
-from src.control_plane.auth.context import AuthorizationContext
 from src.control_plane.auth.provider_clients import ProviderClientRegistry
 from src.control_plane.auth.service import AuthorizationService
 from src.control_plane.models import CloudAccount, ProviderConnection

--- a/tests/control_plane/auth/test_service.py
+++ b/tests/control_plane/auth/test_service.py
@@ -1,0 +1,106 @@
+import pytest
+from sqlalchemy import select
+
+from src.control_plane.auth.context import AuthorizationContext
+from src.control_plane.auth.provider_clients import ProviderClientRegistry
+from src.control_plane.auth.service import AuthorizationService
+from src.control_plane.models import CloudAccount, ProviderConnection
+
+
+@pytest.mark.asyncio
+async def test_resolve_upserts_account_and_independent_connection(control_db):
+    service = AuthorizationService(
+        control_db,
+        ProviderClientRegistry(
+            {"chatgpt-client": "chatgpt", "claude-client": "claude_ai"}
+        ),
+    )
+    first = await service.resolve(
+        subject="auth0|owner-1",
+        client_id="chatgpt-client",
+        scopes={"shipments:preview"},
+    )
+    second = await service.resolve(
+        subject="auth0|owner-1",
+        client_id="claude-client",
+        scopes={"jobs:read"},
+    )
+
+    assert first.account_id == second.account_id
+    assert first.provider_connection_id != second.provider_connection_id
+    assert first.provider_surface == "chatgpt"
+    assert second.provider_surface == "claude_ai"
+
+
+@pytest.mark.asyncio
+async def test_resolve_reuses_active_connection_and_updates_scopes(control_db):
+    service = AuthorizationService(
+        control_db,
+        ProviderClientRegistry({"chatgpt-client": "chatgpt"}),
+    )
+    first = await service.resolve(
+        subject="auth0|owner-1",
+        client_id="chatgpt-client",
+        scopes={"shipments:preview"},
+    )
+    second = await service.resolve(
+        subject="auth0|owner-1",
+        client_id="chatgpt-client",
+        scopes={"jobs:read"},
+    )
+
+    assert first.provider_connection_id == second.provider_connection_id
+
+    connection = await control_db.scalar(
+        select(ProviderConnection).where(
+            ProviderConnection.id == second.provider_connection_id
+        )
+    )
+    assert connection is not None
+    assert connection.scopes_text == "jobs:read"
+
+
+@pytest.mark.asyncio
+async def test_resolve_rejects_suspended_account(control_db):
+    suspended = CloudAccount(auth0_subject="auth0|owner-2", suspended=True)
+    control_db.add(suspended)
+    await control_db.commit()
+
+    service = AuthorizationService(
+        control_db,
+        ProviderClientRegistry({"chatgpt-client": "chatgpt"}),
+    )
+    with pytest.raises(PermissionError, match="suspended"):
+        await service.resolve(
+            subject="auth0|owner-2",
+            client_id="chatgpt-client",
+            scopes={"jobs:read"},
+        )
+
+
+@pytest.mark.asyncio
+async def test_resolve_rejects_inactive_connection(control_db):
+    account = CloudAccount(auth0_subject="auth0|owner-3")
+    control_db.add(account)
+    await control_db.flush()
+    control_db.add(
+        ProviderConnection(
+            account_id=account.id,
+            client_id="chatgpt-client",
+            surface="chatgpt",
+            status="revoked",
+            scopes_text="shipments:preview",
+        )
+    )
+    await control_db.commit()
+
+    service = AuthorizationService(
+        control_db,
+        ProviderClientRegistry({"chatgpt-client": "chatgpt"}),
+    )
+    with pytest.raises(PermissionError, match="not active"):
+        await service.resolve(
+            subject="auth0|owner-3",
+            client_id="chatgpt-client",
+            scopes={"jobs:read"},
+        )

--- a/tests/control_plane/test_app_auth.py
+++ b/tests/control_plane/test_app_auth.py
@@ -1,4 +1,5 @@
 from dataclasses import asdict
+
 from fastapi import Request
 from fastapi.testclient import TestClient
 

--- a/tests/control_plane/test_app_auth.py
+++ b/tests/control_plane/test_app_auth.py
@@ -1,6 +1,6 @@
-from fastapi import FastAPI, Request
+from dataclasses import asdict
+from fastapi import Request
 from fastapi.testclient import TestClient
-import pytest
 
 from src.control_plane.app import create_control_plane_app
 from src.control_plane.auth.context import AuthorizationContext
@@ -33,7 +33,7 @@ class _AuthorizationService(AuthorizationService):
 
 
 def _build_app_with_routes(monkeypatch, database_url: str):
-    monkeypatch.setenv("SHIPAGENT_PUBLIC_BASE_URL", "https://dev-mcp.shipagent.app")
+    monkeypatch.setenv("SHIPAGENT_PUBLIC_BASE_URL", "https://dev-mcp.shipagent.app/")
     monkeypatch.setenv("SHIPAGENT_AUTH0_ISSUER", "https://tenant.us.auth0.com/")
     monkeypatch.setenv("SHIPAGENT_AUTH0_AUDIENCE", "https://dev-mcp.shipagent.app")
     monkeypatch.setenv("SHIPAGENT_DATABASE_URL", database_url)
@@ -46,7 +46,11 @@ def _build_app_with_routes(monkeypatch, database_url: str):
 
     @app.get("/_probe")
     async def probe(request: Request):
-        return {"has_context": hasattr(request.state, "authorization")}
+        authorization = getattr(request.state, "authorization", None)
+        return {
+            "has_context": authorization is not None,
+            "authorization": asdict(authorization) if authorization is not None else None,
+        }
 
     return app
 
@@ -79,4 +83,14 @@ def test_valid_token_populates_context(monkeypatch):
         )
 
     assert response.status_code == 200
-    assert response.json()["has_context"] is True
+    payload = response.json()
+    assert payload["has_context"] is True
+    assert payload["authorization"]["account_id"] == "acct-1"
+    assert payload["authorization"]["provider_connection_id"] == "pc-1"
+    assert payload["authorization"]["provider_surface"] == "chatgpt"
+    assert payload["authorization"]["subject"] == "auth0|owner-1"
+    assert payload["authorization"]["client_id"] == "chatgpt-client"
+    assert set(payload["authorization"]["scopes"]) == {
+        "jobs:read",
+        "shipments:preview",
+    }

--- a/tests/control_plane/test_app_auth.py
+++ b/tests/control_plane/test_app_auth.py
@@ -1,0 +1,82 @@
+from fastapi import FastAPI, Request
+from fastapi.testclient import TestClient
+import pytest
+
+from src.control_plane.app import create_control_plane_app
+from src.control_plane.auth.context import AuthorizationContext
+from src.control_plane.auth.jwt_verifier import TokenPrincipal
+from src.control_plane.auth.service import AuthorizationService
+
+
+class _TokenVerifier:
+    def __init__(self, *args, **kwargs) -> None:
+        pass
+
+    def verify(self, token: str) -> TokenPrincipal:
+        return TokenPrincipal(
+            subject="auth0|owner-1",
+            client_id="chatgpt-client",
+            scopes=frozenset({"jobs:read", "shipments:preview"}),
+        )
+
+
+class _AuthorizationService(AuthorizationService):
+    async def resolve(self, *, subject: str, client_id: str, scopes: set[str]) -> AuthorizationContext:
+        return AuthorizationContext(
+            account_id="acct-1",
+            provider_connection_id="pc-1",
+            provider_surface="chatgpt",
+            subject=subject,
+            client_id=client_id,
+            scopes=frozenset(scopes),
+        )
+
+
+def _build_app_with_routes(monkeypatch, database_url: str):
+    monkeypatch.setenv("SHIPAGENT_PUBLIC_BASE_URL", "https://dev-mcp.shipagent.app")
+    monkeypatch.setenv("SHIPAGENT_AUTH0_ISSUER", "https://tenant.us.auth0.com/")
+    monkeypatch.setenv("SHIPAGENT_AUTH0_AUDIENCE", "https://dev-mcp.shipagent.app")
+    monkeypatch.setenv("SHIPAGENT_DATABASE_URL", database_url)
+    monkeypatch.setenv("SHIPAGENT_REDIS_URL", "redis://127.0.0.1:6379/0")
+
+    monkeypatch.setattr("src.control_plane.app.Auth0TokenVerifier", _TokenVerifier)
+    monkeypatch.setattr("src.control_plane.app.AuthorizationService", _AuthorizationService)
+
+    app = create_control_plane_app()
+
+    @app.get("/_probe")
+    async def probe(request: Request):
+        return {"has_context": hasattr(request.state, "authorization")}
+
+    return app
+
+
+def test_protected_resource_metadata(monkeypatch):
+    app = _build_app_with_routes(monkeypatch, "sqlite+aiosqlite:///:memory:")
+    with TestClient(app) as client:
+        response = client.get("/.well-known/oauth-protected-resource")
+
+    assert response.status_code == 200
+    assert response.json()["resource"] == "https://dev-mcp.shipagent.app"
+    assert response.json()["authorization_servers"] == ["https://tenant.us.auth0.com/"]
+
+
+def test_missing_token_returns_bearer_challenge(monkeypatch):
+    app = _build_app_with_routes(monkeypatch, "sqlite+aiosqlite:///:memory:")
+    with TestClient(app) as client:
+        response = client.get("/_probe")
+
+    assert response.status_code == 401
+    assert "resource_metadata=" in response.headers["www-authenticate"]
+
+
+def test_valid_token_populates_context(monkeypatch):
+    app = _build_app_with_routes(monkeypatch, "sqlite+aiosqlite:///:memory:")
+    with TestClient(app) as client:
+        response = client.get(
+            "/_probe",
+            headers={"Authorization": "Bearer valid-token"},
+        )
+
+    assert response.status_code == 200
+    assert response.json()["has_context"] is True

--- a/tests/control_plane/test_redis_keys.py
+++ b/tests/control_plane/test_redis_keys.py
@@ -4,5 +4,7 @@ from src.control_plane.redis_keys import RedisKey, RedisTtl
 def test_keys_are_namespaced_and_contain_no_payload_data():
     assert RedisKey.relay_session("device-1") == "sa:relay:session:device-1"
     assert RedisKey.invocation("corr-1") == "sa:invocation:corr-1"
+    assert RedisKey.rate_limit("pc-1", "estimate", "1234") == "sa:rate:pc-1:estimate:1234"
+    assert RedisKey.loop_guard("pc-1", "get_job_status", "hash-1") == "sa:loop:pc-1:get_job_status:hash-1"
     assert RedisTtl.RELAY_SESSION_SECONDS == 90
     assert RedisTtl.TERMINAL_JOB_SECONDS == 86400

--- a/tests/control_plane/test_request_controls.py
+++ b/tests/control_plane/test_request_controls.py
@@ -41,7 +41,7 @@ async def test_rate_limit_is_namespaced_by_connection_and_class(fake_controls):
             rate_limit_class="estimate",
             arguments_hash=f"hash-{index}",
         )
-    with pytest.raises(RequestControlError, match="rate_limited"):
+    with pytest.raises(RequestControlError, match="rate limit exceeded"):
         await fake_controls.require_allowed(
             connection_id="connection-1",
             tool_name="get_shipment_rates",

--- a/tests/control_plane/test_request_controls.py
+++ b/tests/control_plane/test_request_controls.py
@@ -1,4 +1,3 @@
-import asyncio
 import time
 
 import pytest
@@ -35,12 +34,12 @@ def fake_controls():
 
 @pytest.mark.asyncio
 async def test_rate_limit_is_namespaced_by_connection_and_class(fake_controls):
-    for _ in range(10):
+    for index in range(10):
         await fake_controls.require_allowed(
             connection_id="connection-1",
             tool_name="get_shipment_rates",
             rate_limit_class="estimate",
-            arguments_hash="hash-1",
+            arguments_hash=f"hash-{index}",
         )
     with pytest.raises(RequestControlError, match="rate_limited"):
         await fake_controls.require_allowed(
@@ -60,7 +59,7 @@ async def test_repeated_identical_calls_trip_loop_breaker(fake_controls):
             rate_limit_class="read",
             arguments_hash="same-hash",
         )
-    with pytest.raises(RequestControlError, match="provider_loop_detected"):
+    with pytest.raises(RequestControlError, match="loop"):
         await fake_controls.require_allowed(
             connection_id="connection-1",
             tool_name="get_job_status",

--- a/tests/control_plane/test_request_controls.py
+++ b/tests/control_plane/test_request_controls.py
@@ -1,0 +1,88 @@
+import asyncio
+import time
+
+import pytest
+
+from src.control_plane.request_controls import RequestControlError, RequestControls
+
+
+class _FakeRedis:
+    def __init__(self):
+        self._values: dict[str, tuple[int, float]] = {}
+
+    async def eval(self, script: str, keys: int, *args: str) -> int:
+        if keys != 1:
+            raise RuntimeError("unexpected keys arg")
+        key = args[0]
+        max_ttl = float(args[1])
+        if key not in self._values:
+            self._values[key] = (0, time.monotonic() + max_ttl)
+        value, expiry = self._values[key]
+        if time.monotonic() > expiry:
+            value = 0
+
+        value += 1
+        if value == 1:
+            expiry = time.monotonic() + max_ttl
+        self._values[key] = (value, expiry)
+        return value
+
+
+@pytest.fixture
+def fake_controls():
+    return RequestControls(_FakeRedis(), now_fn=lambda: 0)
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_is_namespaced_by_connection_and_class(fake_controls):
+    for _ in range(10):
+        await fake_controls.require_allowed(
+            connection_id="connection-1",
+            tool_name="get_shipment_rates",
+            rate_limit_class="estimate",
+            arguments_hash="hash-1",
+        )
+    with pytest.raises(RequestControlError, match="rate_limited"):
+        await fake_controls.require_allowed(
+            connection_id="connection-1",
+            tool_name="get_shipment_rates",
+            rate_limit_class="estimate",
+            arguments_hash="hash-11",
+        )
+
+
+@pytest.mark.asyncio
+async def test_repeated_identical_calls_trip_loop_breaker(fake_controls):
+    for _ in range(3):
+        await fake_controls.require_allowed(
+            connection_id="connection-1",
+            tool_name="get_job_status",
+            rate_limit_class="read",
+            arguments_hash="same-hash",
+        )
+    with pytest.raises(RequestControlError, match="provider_loop_detected"):
+        await fake_controls.require_allowed(
+            connection_id="connection-1",
+            tool_name="get_job_status",
+            rate_limit_class="read",
+            arguments_hash="same-hash",
+        )
+
+
+@pytest.mark.asyncio
+async def test_fake_redis_isolation_of_namespaces(fake_controls):
+    connection_one_task = fake_controls.require_allowed(
+        connection_id="connection-1",
+        tool_name="get_job_status",
+        rate_limit_class="read",
+        arguments_hash="same-hash",
+    )
+    await connection_one_task
+
+    connection_two_task = fake_controls.require_allowed(
+        connection_id="connection-2",
+        tool_name="get_job_status",
+        rate_limit_class="read",
+        arguments_hash="same-hash",
+    )
+    await connection_two_task

--- a/tests/hosted/test_hosted_mcp_registry.py
+++ b/tests/hosted/test_hosted_mcp_registry.py
@@ -1,10 +1,20 @@
 import pytest
 from jsonschema import validate
 
-from src.hosted_mcp.server import build_server
+from src.control_plane.auth.context import (
+    AuthorizationContext,
+    clear_authorization_context,
+    set_authorization_context,
+)
+from src.control_plane.request_controls import RequestControlError, hash_arguments
+from src.hosted_mcp.server import (
+    ToolAuthorizationError,
+    build_server,
+)
 from src.provider_adapters.mcp_projection import to_mcp_tool_descriptor
 from src.registry.catalog import public_tools
 from src.registry.models import ProviderExport
+from src.registry.tools.public import FIRST_SLICE_TOOL_NAMES
 
 
 def tool(name: str):
@@ -32,70 +42,268 @@ async def test_hosted_mcp_server_does_not_register_unbound_catalog_tools():
 
 @pytest.mark.asyncio
 async def test_hosted_mcp_server_requires_exportable_and_bound_tools():
-    async def execute_shipments_handler(arguments):
-        return {"job_id": "job-1", "status": "running"}
+    async def track_package_handler(context, arguments):
+        return {"status": "in_transit", "events": []}
 
-    async def job_status_handler(arguments):
+    async def job_status_handler(context, arguments):
         return {"job_id": arguments["job_id"], "status": "running"}
 
-    registered_tool = exportable_mcp_tool("execute_shipments")
-    provider_excluded = exportable_mcp_tool("get_job_status").model_copy(
+    registered_tool = exportable_mcp_tool("get_shipagent_status")
+    provider_excluded = exportable_mcp_tool("submit_one_off_shipment").model_copy(
         update={"provider_exports": [ProviderExport.openai]}
     )
-    unbound_tool = exportable_mcp_tool("create_label_download")
+    unbound_tool = exportable_mcp_tool("get_shipment_rates")
 
     server = build_server(
         tools=[registered_tool, provider_excluded, unbound_tool],
         tool_handlers={
-            "execute_shipments": execute_shipments_handler,
-            "get_job_status": job_status_handler,
+            "get_shipagent_status": track_package_handler,
+            "submit_one_off_shipment": job_status_handler,
         },
     )
     tools = await server.get_tools()
 
-    assert set(tools) == {"execute_shipments"}
+    assert set(tools) == {"get_shipagent_status"}
 
 
 @pytest.mark.asyncio
 async def test_hosted_mcp_tool_metadata_and_schemas_come_from_registry():
-    async def handler(arguments):
-        return {"job_id": "job-1", "status": "running"}
+    async def handler(context, arguments):
+        return {
+            "status": "healthy",
+            "active_device_id": "device-1",
+            "capabilities": ["rate", "ship"],
+        }
 
-    contract = exportable_mcp_tool("execute_shipments")
+    contract = exportable_mcp_tool("get_shipagent_status")
     descriptor = to_mcp_tool_descriptor(contract)
     server = build_server(
         tools=[contract],
-        tool_handlers={"execute_shipments": handler},
+        tool_handlers={"get_shipagent_status": handler},
     )
     tools = await server.get_tools()
-    registered = tools["execute_shipments"]
+    registered = tools["get_shipagent_status"]
 
     assert registered.title == contract.title
     assert registered.description == contract.description
-    assert registered.annotations.readOnlyHint is False
-    assert registered.annotations.destructiveHint is False
-    assert registered.annotations.openWorldHint is True
     assert registered.parameters == descriptor["inputSchema"]
     assert registered.output_schema == descriptor["outputSchema"]
 
 
 @pytest.mark.asyncio
 async def test_hosted_mcp_bound_handler_result_matches_advertised_schema():
-    async def handler(arguments):
-        return {"job_id": "job-1", "status": "running"}
+    async def handler(context, arguments):
+        return {
+            "status": "healthy",
+            "active_device_id": "device-1",
+            "capabilities": ["rate", "ship"],
+        }
 
-    contract = exportable_mcp_tool("execute_shipments")
+    contract = exportable_mcp_tool("get_shipagent_status")
     server = build_server(
         tools=[contract],
-        tool_handlers={"execute_shipments": handler},
+        tool_handlers={"get_shipagent_status": handler},
+    )
+    tools = await server.get_tools()
+    context = AuthorizationContext(
+        account_id="acct-1",
+        provider_connection_id="pc-1",
+        provider_surface="chatgpt",
+        subject="auth0|owner-1",
+        client_id="chatgpt-client",
+        scopes=frozenset({"account:read", "device:read"}),
+    )
+
+    token = set_authorization_context(context)
+    try:
+        result = await tools["get_shipagent_status"].run({"correlation_id": "corr-1"})
+    finally:
+        clear_authorization_context(token)
+
+    assert result.structured_content == {
+        "status": "healthy",
+        "active_device_id": "device-1",
+        "capabilities": ["rate", "ship"],
+    }
+    validate(
+        instance=result.structured_content,
+        schema=tools["get_shipagent_status"].output_schema,
+    )
+
+
+@pytest.mark.asyncio
+async def test_hosted_mcp_handler_rejects_missing_authorization_context():
+    async def handler(context, arguments):
+        return {
+            "status": "healthy",
+            "active_device_id": "device-1",
+            "capabilities": ["rate", "ship"],
+        }
+
+    contract = exportable_mcp_tool("get_shipagent_status")
+    server = build_server(
+        tools=[contract],
+        tool_handlers={"get_shipagent_status": handler},
     )
     tools = await server.get_tools()
 
-    result = await tools["execute_shipments"].run(
-        {"preview_id": "preview-1", "confirmation_token": "token-1"}
-    )
+    with pytest.raises(ToolAuthorizationError) as exc:
+        await tools["get_shipagent_status"].run({"correlation_id": "corr-1"})
 
-    assert result.structured_content == {"job_id": "job-1", "status": "running"}
-    validate(
-        instance=result.structured_content, schema=tools["execute_shipments"].output_schema
+    assert exc.value.code == "missing_authorization_context"
+
+
+@pytest.mark.asyncio
+async def test_hosted_mcp_handler_rejects_missing_scopes():
+    async def handler(context, arguments):
+        return {
+            "status": "healthy",
+            "active_device_id": "device-1",
+            "capabilities": ["rate", "ship"],
+        }
+
+    contract = exportable_mcp_tool("get_shipagent_status")
+    server = build_server(
+        tools=[contract],
+        tool_handlers={"get_shipagent_status": handler},
     )
+    tools = await server.get_tools()
+    context = AuthorizationContext(
+        account_id="acct-1",
+        provider_connection_id="pc-1",
+        provider_surface="chatgpt",
+        subject="auth0|owner-1",
+        client_id="chatgpt-client",
+        scopes=frozenset({"account:read"}),
+    )
+    token = set_authorization_context(context)
+    try:
+        with pytest.raises(ToolAuthorizationError) as exc:
+            await tools["get_shipagent_status"].run({"correlation_id": "corr-1"})
+    finally:
+        clear_authorization_context(token)
+
+    assert exc.value.code == "insufficient_scope"
+    assert exc.value.required_scopes == ["device:read"]
+
+
+@pytest.mark.asyncio
+async def test_hosted_mcp_handler_applies_request_controls_before_invocation():
+    calls = []
+
+    class _RequestControls:
+        async def require_allowed(
+            self,
+            *,
+            connection_id: str,
+            tool_name: str,
+            rate_limit_class: str,
+            arguments_hash: str,
+        ) -> None:
+            calls.append(
+                {
+                    "connection_id": connection_id,
+                    "tool_name": tool_name,
+                    "rate_limit_class": rate_limit_class,
+                    "arguments_hash": arguments_hash,
+                }
+            )
+
+    invoked = {"value": False}
+
+    async def handler(context, arguments):
+        invoked["value"] = True
+        return {"rates": [{"carrier": "UPS"}], "selected": "ups"}
+
+    contract = exportable_mcp_tool("get_shipment_rates").model_copy(
+        update={"rate_limit_class": "estimate"}
+    )
+    server = build_server(
+        tools=[contract],
+        tool_handlers={"get_shipment_rates": handler},
+        request_controls=_RequestControls(),
+    )
+    tools = await server.get_tools()
+    context = AuthorizationContext(
+        account_id="acct-1",
+        provider_connection_id="pc-1",
+        provider_surface="chatgpt",
+        subject="auth0|owner-1",
+        client_id="chatgpt-client",
+        scopes=frozenset({"shipments:rate"}),
+    )
+    token = set_authorization_context(context)
+    try:
+        result = await tools["get_shipment_rates"].run({"shipment_id": "ship-1"})
+    finally:
+        clear_authorization_context(token)
+
+    assert invoked["value"] is True
+    assert result.structured_content == {"rates": [{"carrier": "UPS"}], "selected": "ups"}
+    assert calls == [
+        {
+            "connection_id": "pc-1",
+            "tool_name": "get_shipment_rates",
+            "rate_limit_class": "estimate",
+            "arguments_hash": hash_arguments({"shipment_id": "ship-1"}),
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_hosted_mcp_handler_translates_request_control_deny():
+    invoked = {"value": False}
+
+    async def handler(context, arguments):
+        invoked["value"] = True
+        return {
+            "status": "healthy",
+            "active_device_id": "device-1",
+            "capabilities": ["rate", "ship"],
+        }
+
+    class _RequestControls:
+        async def require_allowed(
+            self,
+            *,
+            connection_id: str,
+            tool_name: str,
+            rate_limit_class: str,
+            arguments_hash: str,
+        ) -> None:
+            raise RequestControlError(
+                code="provider_loop_detected",
+                message="identical call loop detected",
+            )
+
+    contract = exportable_mcp_tool("get_shipagent_status")
+    server = build_server(
+        tools=[contract],
+        tool_handlers={"get_shipagent_status": handler},
+        request_controls=_RequestControls(),
+    )
+    tools = await server.get_tools()
+    context = AuthorizationContext(
+        account_id="acct-1",
+        provider_connection_id="pc-1",
+        provider_surface="chatgpt",
+        subject="auth0|owner-1",
+        client_id="chatgpt-client",
+        scopes=frozenset({"account:read", "device:read"}),
+    )
+    token = set_authorization_context(context)
+    try:
+        with pytest.raises(ToolAuthorizationError) as exc:
+            await tools["get_shipagent_status"].run({"correlation_id": "corr-1"})
+    finally:
+        clear_authorization_context(token)
+
+    assert exc.value.code == "provider_loop_detected"
+    assert invoked["value"] is False
+
+
+@pytest.mark.parametrize("tool_name", FIRST_SLICE_TOOL_NAMES)
+def test_first_slice_public_input_schema_rejects_identity_fields(tool_name: str):
+    prohibited = {"account_id", "tenant_id", "provider_connection_id", "user_id"}
+    contract = tool(tool_name)
+    assert prohibited.isdisjoint(set(contract.input_schema["properties"]))


### PR DESCRIPTION
Implements RFC 9728 OAuth-protected MCP resource authorization and hosted MCP scope/control enforcement.

- Adds immutable AuthorizationContext + provider-client registry.
- Adds Auth0 token verification and claims validation.
- Adds cloud account/provider connection resolution service.
- Adds Redis-backed rate-limit and loop detection controls.
- Adds OAuth metadata endpoint and auth middleware with WWW-Authenticate challenge.
- Adds control-plane app creation for authenticated Streamable MCP.
- Enforces scope and request controls in hosted tool invocation.
- Updates tool-registration tests and adds auth/request-control tests.
- Adds docs and metadata checker script.